### PR TITLE
More CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,3 +7,5 @@ build --worker_sandboxing
 build --experimental_reuse_sandbox_directories
 build --incompatible_enable_cc_toolchain_resolution
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+try-import %workspace%/.custom.ci.bazelrc

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,39 @@
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the Apache License, Version 2.0
+
 steps:
-  - label: "Build"
-    command: tools/bazel build //...
+  - label: "Test"
+    command: |
+      . .buildkite/setup-bazelrc.sh
+      ci/test
   - label: "Lint"
-    command: ci/lint
+    command: |
+      . .buildkite/setup-bazelrc.sh
+      ci/lint
+  - label: "List Platforms"
+    command: "ci/list_toolchains_platforms"
+  - label: "Test Release and Launcher scripts"
+    command: |
+      git config --global user.email "buildkite@example.com"
+      git config --global user.name "Buildkite Bot"
+
+      echo "--- ci/release"
+      ci/release
+      echo "--- ci/launcher"
+      ci/launcher
+  - label: "Test Launcher on wine64"
+    plugins:
+      - docker#v5.5.0:
+          image: "debian:stable"
+    command: |
+      apt-get update && apt-get install --no-install-recommends -y \
+        wine64 python3 ca-certificates
+      ci/launcher-wine64
+  - label: "mod-tidy and update-repos"
+    command: |
+      . .buildkite/setup-bazelrc.sh
+      bin/mod-tidy
+      git diff --exit-code
 agents:
     - "queue=init"
     - "docker=*"

--- a/.buildkite/setup-bazelrc.sh
+++ b/.buildkite/setup-bazelrc.sh
@@ -1,0 +1,15 @@
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the Apache License, Version 2.0
+
+if [ -z "${BUILDKITE_BUILD_NUMBER:-}" ]; then
+    >&2 echo "error: expected to run in buildkite"
+    exit 1
+fi
+
+export BAZEL_ZIG_CC_CACHE_PREFIX="/tmp/bazel-zig-cc${BUILDKITE_BUILD_NUMBER}"
+mkdir -p "$BAZEL_ZIG_CC_CACHE_PREFIX"
+
+cat > .custom.ci.bazelrc <<EOF
+common --repo_env BAZEL_ZIG_CC_CACHE_PREFIX="$BAZEL_ZIG_CC_CACHE_PREFIX"
+build --sandbox_writable_path "$BAZEL_ZIG_CC_CACHE_PREFIX"
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /bazel-out
 /bazel-testlogs
 /bazel-x
+
+.custom.ci.bazelrc

--- a/bin/buildifier
+++ b/bin/buildifier
@@ -1,4 +1,8 @@
 #!/bin/sh
-set -eu
 
-"$(git rev-parse --show-toplevel)/tools/bazel" run @com_github_bazelbuild_buildtools//buildifier -- $@
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the Apache License, Version 2.0
+
+set -xeu
+
+exec "$(git rev-parse --show-toplevel)/tools/bazel" run @com_github_bazelbuild_buildtools//buildifier -- "$@"

--- a/bin/mod-tidy
+++ b/bin/mod-tidy
@@ -2,8 +2,11 @@
 
 # Copyright 2023 Uber Technologies, Inc.
 # Licensed under the Apache License, Version 2.0
-set -eu
+set -xeu
 
 cd "$(git rev-parse --show-toplevel)/"
-bazel run @go_sdk//:bin/go -- mod tidy
-exec bazel run //:gazelle-update-repos
+echo "--- go mod tidy"
+tools/bazel run @go_sdk//:bin/go -- mod tidy
+
+echo "--- gazelle-update-repos"
+exec tools/bazel run //:gazelle-update-repos

--- a/ci/launcher
+++ b/ci/launcher
@@ -5,8 +5,10 @@
 
 set -xeuo pipefail
 
-ZIG=${ZIG:-$(bazel run "$@" --run_under=echo @zig_sdk//:zig)}
+echo "--- which zig"
+ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
 
+echo "--- compile launcher.zig for various architectures"
 for target in \
     aarch64-linux-gnu.2.19 \
     aarch64-macos-none \
@@ -17,15 +19,9 @@ do
     $ZIG build-exe -fno-emit-bin -target $target toolchain/launcher.zig
 done
 
+echo "--- zig fmt --check toolchain/launcher.zig"
 $ZIG fmt --check toolchain/launcher.zig
 
+echo "--- zig test toolchain/launcher.zig"
 # until bazel-zig-cc gets a zig toolchain, run launcher's unit tests here.
 $ZIG test toolchain/launcher.zig
-
-# ReleaseSafe because of https://github.com/ziglang/zig/issues/14036
-$ZIG test \
-    -OReleaseSafe \
-    -target x86_64-windows-gnu \
-    --test-cmd wine64-stable \
-    --test-cmd-bin \
-    toolchain/launcher.zig

--- a/ci/launcher-wine64
+++ b/ci/launcher-wine64
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the Apache License, Version 2.0
+
+set -xeuo pipefail
+
+echo "--- which zig"
+ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
+
+echo "--- test toolchain/launcher.zig via wine64"
+# ReleaseSafe because of https://github.com/ziglang/zig/issues/14036
+$ZIG test \
+    -OReleaseSafe \
+    -target x86_64-windows-gnu \
+    --test-cmd wine64-stable \
+    --test-cmd-bin \
+    toolchain/launcher.zig

--- a/ci/list_toolchains_platforms
+++ b/ci/list_toolchains_platforms
@@ -7,13 +7,13 @@ set -euo pipefail
 
 indent() { sed 's/^/    /'; }
 
-echo "Available toolchains:"
-bazel query --noshow_progress '@zig_sdk//toolchain:*' | indent
-echo "Available platforms:"
-bazel query --noshow_progress '@zig_sdk//platform:*' | indent
-echo "Available libc aware toolchains:"
-bazel query --noshow_progress '@zig_sdk//libc_aware/toolchain:*' | indent
-echo "Available libc aware platforms:"
-bazel query --noshow_progress '@zig_sdk//libc_aware/platform:*' | indent
-echo "Available libc variants:"
-bazel query --noshow_progress "attr(constraint_setting, @zig_sdk//libc:variant, @zig_sdk//...)" | indent
+echo "--- Available toolchains:"
+tools/bazel query --noshow_progress '@zig_sdk//toolchain:*' | indent
+echo "--- Available platforms:"
+tools/bazel query --noshow_progress '@zig_sdk//platform:*' | indent
+echo "--- Available libc aware toolchains:"
+tools/bazel query --noshow_progress '@zig_sdk//libc_aware/toolchain:*' | indent
+echo "--- Available libc aware platforms:"
+tools/bazel query --noshow_progress '@zig_sdk//libc_aware/platform:*' | indent
+echo "--- Available libc variants:"
+tools/bazel query --noshow_progress "attr(constraint_setting, @zig_sdk//libc:variant, @zig_sdk//...)" | indent

--- a/ci/test
+++ b/ci/test
@@ -5,24 +5,26 @@
 
 set -xeuo pipefail
 
-BAZEL_ZIG_CC_CACHE_PREFIX=${BAZEL_ZIG_CC_CACHE_PREFIX:-/tmp/bazel-zig-cc}
-mkdir -p "${BAZEL_ZIG_CC_CACHE_PREFIX}"
-
 # check a very hermetic setup with a single target. Re-building all of
 # them takes a long time, so using only one. If we ever decide to build all
 # targets, we will need to exclude Go, since go dynamically links to glibc on
 # linux.
-bazel build "$@" \
+echo "--- build a single target with very hermetic sandbox"
+tools/bazel build "$@" \
     --experimental_use_hermetic_linux_sandbox \
     --sandbox_add_mount_pair=/proc \
     //test/c:which_libc_linux_amd64_gnu.2.19
 
 # then test everything else with the standard sandbox
-bazel test "$@" ...
+echo "--- bazel test $@ ..."
+tools/bazel test "$@" ...
 
-# Ensure that github.com/ziglang/zig/issues/13050 does not regress
-find "$BAZEL_ZIG_CC_CACHE_PREFIX" -name mutex_destructor.o -execdir file '{}' \; | \
-    sort | uniq -c | sort -rn > /tmp/got_cache
+echo "--- ensure github.com/ziglang/zig/issues/13050 does not regress"
+find "${BAZEL_ZIG_CC_CACHE_PREFIX:-/tmp/bazel-zig-cc}" \
+    -name mutex_destructor.o -execdir file '{}' \; \
+    | sort \
+    | uniq -c \
+    | sort -rn > /tmp/got_cache
 
 diff -u ci/testdata/want_cache /tmp/got_cache || {
     >&2 echo "ERROR: unexpected artifacts. This is TODO."

--- a/release
+++ b/release
@@ -27,12 +27,13 @@ last_tag=$(git -c 'versionsort.suffix=-' tag -l --sort=v:refname | tail -1)
     echo Changelog since "$last_tag":
     git log --pretty=format:"- [%an] %s" "$last_tag"..HEAD | \
         grep -v "Update release notes for $last_tag"
-} | git tag "${sign[@]}" -F - "$1"
+} | git tag "${sign[@]+"${sign[@]}"}" -F - "$1"
 
 shasum=$(git archive --prefix="bazel-zig-cc-$1/" --format=tar "$1" | \
     gzip -n | sha256sum | cut -f1 -d" ")
 
-./relnotes.awk -v tag="$1" -v sha256sum="$shasum" README.md | sponge README.md
+./relnotes.awk -v tag="$1" -v sha256sum="$shasum" README.md > .README.md
+mv .README.md README.md
 
 git add README.md
 git commit -m "Update release notes for $1"

--- a/test/c/BUILD
+++ b/test/c/BUILD
@@ -13,9 +13,7 @@ cc_binary(
         platform_binary(
             name = "which_libc_{}".format(name),
             src = "which_libc",
-            env = {"QEMU_LD_PREFIX": "/usr/aarch64-linux-gnu"} if "arm64" in name else {},
             platform = platform,
-            run_under = "qemu-aarch64-static" if "arm64" in name else "",
         ),
         sh_test(
             name = "test_libc_{}".format(name),
@@ -31,8 +29,6 @@ cc_binary(
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl", "non-glibc"),
         ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19", "glibc_2.19"),
         ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28", "glibc_2.28"),
-        ("linux_arm64_musl", "//libc_aware/platform:linux_arm64_musl", "non-glibc"),
         ("linux_amd64", "//platform:linux_amd64", "glibc_2.19"),
-        ("linux_arm64", "//platform:linux_arm64", "glibc_2.28"),
     ]
 ]

--- a/test/cgo/BUILD
+++ b/test/cgo/BUILD
@@ -44,14 +44,10 @@ go_binary(
     platform_test(
         name = "cgo_test_{}".format(name),
         src = "cgo_test",
-        env = {"QEMU_LD_PREFIX": "/usr/aarch64-linux-gnu"} if is_arm64 else {},
         platform = platform,
-        run_under = "qemu-aarch64-static" if is_arm64 else "",
     )
     for name, platform, is_arm64 in [
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl", False),
         ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19", False),
-        ("linux_arm64_musl", "//libc_aware/platform:linux_arm64_musl", True),
-        ("linux_arm64_gnu.2.28", "//libc_aware/platform:linux_arm64_gnu.2.28", True),
     ]
 ]

--- a/test/windows/BUILD
+++ b/test/windows/BUILD
@@ -9,12 +9,19 @@ cc_binary(
     tags = ["manual"],
 )
 
-platform_test(
+# TODO(motiejus): bring back windows tests, not only builds
+#platform_test(
+#    name = "winver_windows_amd64",
+#    src = "winver",
+#    platform = "//platform:windows_amd64",
+#    run_under = "wine64-stable",
+#    tags = ["no-sandbox"],
+#)
+
+platform_binary(
     name = "winver_windows_amd64",
     src = "winver",
     platform = "//platform:windows_amd64",
-    run_under = "wine64-stable",
-    tags = ["no-sandbox"],
 )
 
 platform_binary(


### PR DESCRIPTION
- ci only: use a separate zig cache dir for each run
- use `tools/bazel` everywhere.
- remove arm64 tests. They don't give enough value to be worth the
  brittle environment.
- remove windows execution, except for launcher. Ditto. I will probably
  bring them back.

