### PR TITLE
rules/ remove run_under

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -17,7 +17,7 @@ tools/bazel build "$@" \
     --experimental_use_hermetic_linux_sandbox \
     --sandbox_writable_path="$cache_prefix" \
     --sandbox_add_mount_pair=/proc \
-    //test/c:which_libc_linux_amd64_gnu.2.19
+    //test/c:which_libc
 
 # then test everything else with the standard sandbox
 echo "--- bazel test $* ..."

--- a/rules/platform.bzl
+++ b/rules/platform.bzl
@@ -21,10 +21,10 @@ def _platform_binary_impl(ctx):
     platform_sanitized = ctx.attr.platform.replace("/", "_").replace(":", "_")
     dst = ctx.actions.declare_file("{}-{}".format(paths.basename(ctx.file.src.path), platform_sanitized))
     src = ctx.file.src
-    ctx.actions.run_shell(
+    ctx.actions.run(
         outputs = [dst],
         inputs = [src],
-        command = "cp $1 $2",
+        executable = "cp",
         arguments = [src.path, dst.path],
     )
     return [DefaultInfo(

--- a/test/windows/BUILD
+++ b/test/windows/BUILD
@@ -9,15 +9,6 @@ cc_binary(
     tags = ["manual"],
 )
 
-# TODO(motiejus): bring back windows tests, not only builds
-#platform_test(
-#    name = "winver_windows_amd64",
-#    src = "winver",
-#    platform = "//platform:windows_amd64",
-#    run_under = "wine64-stable",
-#    tags = ["no-sandbox"],
-#)
-
 platform_binary(
     name = "winver_windows_amd64",
     src = "winver",


### PR DESCRIPTION
rules/ were never meant to be added to the release. Now that we are not *running* multi-arch binaries, we can remove the infrastructure that was necessary to do so.

I may get back to this -- but we need to dust quite a bit off before that happens.