### PR TITLE
launcher: use `-mcpu=baseline`

### DIFF
--- a/ci/launcher
+++ b/ci/launcher
@@ -16,7 +16,12 @@ for target in \
     x86_64-macos-none \
     x86_64-windows-gnu
 do
-    $ZIG build-exe -fno-emit-bin -target $target toolchain/launcher.zig
+    if [[ $target == aarch64-macos-none ]]; then
+        mcpu=apple_a14
+    else
+        mcpu=baseline
+    fi
+    $ZIG build-exe -fno-emit-bin -target $target -mcpu=$mcpu toolchain/launcher.zig
 done
 
 echo "--- zig fmt --check toolchain/launcher.zig"

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -42,6 +42,14 @@ _HOST_PLATFORM_EXT = {
     "windows-x86_64": "zip",
 }
 
+_MCPU = {
+    "linux-aarch64": "baseline",
+    "linux-x86_64": "baseline",
+    "macos-aarch64": "apple_a14",
+    "macos-x86_64": "baseline",
+    "windows-x86_64": "baseline",
+}
+
 _compile_failed = """
 Compilation of launcher.zig failed:
 command={compile_cmd}
@@ -199,6 +207,7 @@ def _zig_repository_impl(repository_ctx):
     compile_cmd = [
         paths.join("..", "zig"),
         "build-exe",
+        "-mcpu={}".format(_MCPU[host_platform]),
         "-OReleaseSafe",
         "launcher.zig",
     ] + (["-static"] if os == "linux" else [])


### PR DESCRIPTION
This log message has been seen in a Github Actions worker:

      running <...>/c++ failed: signal: illegal instruction (core dumped)

I conclude that the launcher was compiled on a newer CPU than used on the worker at the time.

Reported-by: mp@edgeless.systems

Fixes #22