### PR TITLE
Re-add linkopts and set -Wl,-headerpad_max_install_names on macos

### DIFF
--- a/toolchain/private/cc_toolchains.bzl
+++ b/toolchain/private/cc_toolchains.bzl
@@ -30,7 +30,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
 
         dynamic_library_linkopts = target_config.dynamic_library_linkopts
         copts = target_config.copts
-        linkopts = []
+        linkopts = target_config.linkopts
 
         # We can't pass a list of structs to a rule, so we use json encoding.
         artifact_name_patterns = getattr(target_config, "artifact_name_patterns", [])

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -63,6 +63,7 @@ def _target_macos(gocpu, zigcpu):
             "libc/include/any-macos.{}-any".format(min_os),
             "libc/include/any-macos-any",
         ] + _INCLUDE_TAIL,
+        linkopts = ["-Wl,-headerpad_max_install_names"],
         dynamic_library_linkopts = ["-Wl,-undefined=dynamic_lookup"],
         copts = copts,
         libc = "darwin",
@@ -90,6 +91,7 @@ def _target_windows(gocpu, zigcpu):
             "libunwind/include",
             "libc/include/any-windows-any",
         ] + _INCLUDE_TAIL,
+        linkopts = [],
         dynamic_library_linkopts = [],
         copts = [],
         libc = "mingw",
@@ -133,6 +135,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
                    (["libc/include/{}-linux-any".format(zigcpu)] if zigcpu != "x86_64" else []) + [
             "libc/include/any-linux-any",
         ] + _INCLUDE_TAIL,
+        linkopts = [],
         dynamic_library_linkopts = [],
         copts = [],
         libc = "glibc",
@@ -159,6 +162,7 @@ def _target_linux_musl(gocpu, zigcpu):
                    (["libc/include/{}-linux-any".format(zigcpu)] if zigcpu != "x86_64" else []) + [
             "libc/include/any-linux-any",
         ] + _INCLUDE_TAIL,
+        linkopts = [],
         dynamic_library_linkopts = [],
         copts = ["-D_LIBCPP_HAS_MUSL_LIBC", "-D_LIBCPP_HAS_THREAD_API_PTHREAD"],
         libc = "musl",

--- a/toolchain/zig_toolchain.bzl
+++ b/toolchain/zig_toolchain.bzl
@@ -114,20 +114,28 @@ def _zig_cc_toolchain_config_impl(ctx):
         ],
     )
 
+    link_flag_sets = []
+
+    if ctx.attr.linkopts:
+        link_flag_sets += [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ctx.attr.linkopts)],
+            ),
+        ]
+
     if ctx.attr.dynamic_library_linkopts:
-        dynamic_library_flag_sets = [
+        link_flag_sets += [
             flag_set(
                 actions = dynamic_library_link_actions,
                 flag_groups = [flag_group(flags = ctx.attr.dynamic_library_linkopts)],
             ),
         ]
-    else:
-        dynamic_library_flag_sets = []
 
     default_linker_flags = feature(
         name = "default_linker_flags",
         enabled = True,
-        flag_sets = dynamic_library_flag_sets,
+        flag_sets = link_flag_sets,
     )
 
     supports_dynamic_linker = feature(


### PR DESCRIPTION
When building artifacts for macos, pass the `-Wl,-headerpad_max_install_names` linker option to leave space for modifying things like `rpath`.

The built-in toolchain also does it [here](https://github.com/bazelbuild/bazel/blob/0a10409e90f4f6301c24b3743cce90ad8012a81f/tools/cpp/unix_cc_configure.bzl#L599).

Also fixed an issue where the `.map` files under `glibc-hacks` weren't being included in the list of toolchain files.