### PR TITLE
README: bring the compat name of `http_archive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this to your `WORKSPACE`:
 HERMETIC_CC_TOOLCHAIN_VERSION = "v1.0.1"
 
 http_archive(
-    name = "hermetic_cc_toolchain",
+    name = "bazel-zig-cc",
     sha256 = "e9f82bfb74b3df5ca0e67f4d4989e7f1f7ce3386c295fd7fda881ab91f83e509",
     strip_prefix = "bazel-zig-cc-{}".format(HERMETIC_CC_TOOLCHAIN_VERSION),
     urls = [
@@ -48,7 +48,7 @@ http_archive(
     ],
 )
 
-load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
 # version, url_formats and host_platform_sha256 are optional for those who
 # want to control their Zig SDK version.


### PR DESCRIPTION
The recent repository rename broke the assumption about the repository name.

We will soon (hopefully next week) release v2 with all the occurrences of `bazel-zig-cc` removed, and all of this will be over. Sorry for the confusion/mess until that happens.

Fixes #39