### PR TITLE
releaser: add MODULE.bazel

### DIFF
--- a/tools/releaser/main.go
+++ b/tools/releaser/main.go
@@ -24,6 +24,7 @@ var (
 	_paths = []string{
 		"LICENSE",
 		"README.md",
+		"MODULE.bazel",
 		"toolchain/*",
 	}
 


### PR DESCRIPTION
To make bzlMod work.

Test:

    $ tar -tvf hermetic_cc_toolchain-v99.0.0.tar.gz | grep MODULE.bazel
    -rw-rw-r-- root/root       561 2023-04-24 21:03 MODULE.bazel