### PR TITLE
zig cache dir: move to `/tmp/zig-cache`

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -5,7 +5,7 @@
 
 set -xeuo pipefail
 
-cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-/tmp/hermetic_cc_toolchain}"
+cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-/tmp/zig-cache}"
 
 # check a very hermetic setup with a single target. Re-building all of
 # them takes a long time, so using only one. If we ever decide to build all

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -154,7 +154,7 @@ def _zig_repository_impl(repository_ctx):
         if os == "windows":
             cache_prefix = "C:\\\\Temp\\\\hermetic_cc_toolchain"
         else:
-            cache_prefix = "/tmp/hermetic_cc_toolchain"
+            cache_prefix = "/tmp/zig-cache"
 
     repository_ctx.template(
         "tools/launcher.zig",


### PR DESCRIPTION
This cache directory can be re-used by everything and everyone. There is nothing bazel or hermetic_cc_toolchain specific there. So let's make it clear.

Also, if there are any more zig-based toolchains on top of Bazel or other build systems where they cannot rely on $HOME, but need an absolute path, this feels like a reasonable choice.