### PR TITLE
update releaser boilerplate + encourage v2.0.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,22 @@ was moved to [the Uber GitHub repository](https://github.com/uber) and renamed t
 Add this to your `WORKSPACE`:
 
 ```
-HERMETIC_CC_TOOLCHAIN_VERSION = "v1.0.1"
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0-rc1"
 
 http_archive(
-    name = "bazel-zig-cc",
-    sha256 = "e9f82bfb74b3df5ca0e67f4d4989e7f1f7ce3386c295fd7fda881ab91f83e509",
-    strip_prefix = "bazel-zig-cc-{}".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+    name = "hermetic_cc_toolchain",
+    sha256 = "43a1b398f08109c4f03b9ba2b3914bd43d1fec0425f71b71f802bf3f78cee0c2",
     urls = [
-        "https://mirror.bazel.build/github.com/uber/bazel-zig-cc/releases/download/{0}/{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
-        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
     ],
 )
 
-load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains = "toolchains")
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
-# version, url_formats and host_platform_sha256 are optional for those who
-# want to control their Zig SDK version.
-zig_toolchains(
-    version = "<...>",
-    url_formats = [
-        "https://example.org/zig/zig-{host_platform}-{version}.{_ext}",
-    ],
-    host_platform_sha256 = { ... },
-)
+zig_toolchains()
 ```
 
 And this to `.bazelrc`:

--- a/ci/release
+++ b/ci/release
@@ -7,8 +7,7 @@ set -xeuo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 prev_ref=$(git rev-parse HEAD)
-git commit --allow-empty -m "this is a test commit"
-tools/bazel run //tools/releaser -- -tag v99.0.0
+tools/bazel run //tools/releaser -- -tag v99.0.0 -skipBranchCheck
 cleanup() { git tag -d v99.0.0; git reset --hard "$prev_ref"; }
 trap cleanup EXIT
 

--- a/tools/releaser/README
+++ b/tools/releaser/README
@@ -1,0 +1,10 @@
+hermetic_cc_toolchain
+---------------------
+
+See https://github.com/uber/hermetic_cc_toolchain for how to use this.
+
+The release tarball does not contain the full README, because the full README
+includes a hash of the release tarball. Unfortunately, we cannot put the hash
+of the tarball into a text file in the same tarball.
+
+Call me after we crack sha256.


### PR DESCRIPTION
A few changes:
- Now it will write the right boilerplate to `README.md` and `examples/rules_cc/WORKSPACE`.
- tightened the release tarball: it now will depend only on the file content, but not the specific SHA from which the release is created. This way we can cut a release and update the README of the release tarballs *in the same commit*.
- In an upcoming PR the release script will verify that boilerplate in `README.md` and `examples/rules_cc/WORKSPACE` are up to date. But we need to cut `v2.0.0-rc2` first; which I will do with this release script. I will also update the release process wiki with the added features of this tool.

The releaser tool is intended to be used in two modes:

1. *Making* the release: the target tag does not exist.
2. *CI*: the target tag does exist.

The release tool supports both. Second case is a bit more interesting: it will create the release tarball, update the boilerplate from that file, but will not run `git tag`. That way, the CI job can verify that the README.md have unchanged. The CI is expected to run this with the last git tag; that way we will be sure that the examples and the README are up to date.

Fixes #38