### PR TITLE
check-only mode, for v2.0.0-rc2

### DIFF
--- a/ci/release_boilerplate
+++ b/ci/release_boilerplate
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the MIT License
+
+set -xeuo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+>&2 echo "--- releaser :flag-lv:"
+TAG=$(git tag | tail -1)
+tools/bazel run //tools/releaser -- -tag "$TAG" -skipBranchCheck
+
+>&2 echo "--- git diff :git:"
+git diff --exit-code
+
+>&2 echo "OK :white_check_mark:"

--- a/tools/releaser/main_test.go
+++ b/tools/releaser/main_test.go
@@ -24,7 +24,7 @@ func TestRegex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("tag=%s good=%s", tt.tag, tt.good), func(t *testing.T) {
-			matched := tagRegexp.MatchString(tt.tag)
+			matched := _tagRegexp.MatchString(tt.tag)
 
 			if tt.good && !matched {
 				t.Errorf("expected %s to be a valid tag, but it was not", tt.tag)


### PR DESCRIPTION
This mode will be used that the version and the hash in `README.md` and  `examples/rules_cc/WORKSPACE` are up to date.