### PR TITLE
launcher: rename to zig-wrapper + passthrough mode

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,23 +8,23 @@ steps:
     command: ci/lint
   - label: "List Platforms"
     command: ci/list_toolchains_platforms
-  - label: "Test Release and Launcher scripts"
+  - label: "Test Release and zig-wrapper scripts"
     command: |
       git config --global user.email "buildkite@example.com"
       git config --global user.name "Buildkite Bot"
 
       echo "--- ci/release"
       ci/release
-      echo "--- ci/launcher"
-      ci/launcher
-  - label: "Test Launcher on wine64"
+      echo "--- ci/zig-wrapper"
+      ci/zig-wrapper
+  - label: "Test zig-wrapper on wine64"
     plugins:
       - docker#v5.5.0:
           image: "debian:stable"
     command: |
       apt-get update && apt-get install --no-install-recommends -y \
         wine64 python3 ca-certificates
-      ci/launcher-wine64
+      ci/zig-wrapper-wine64
   - label: "Test rules_cc example"
     command: |
       git config --global user.email "buildkite@example.com"

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ $ docker run -e CC=/usr/bin/false -ti --rm -v "$PWD:/x" -w /x debian:bookworm-sl
 # ./ci/lint
 # ./ci/release
 # ./ci/test
+# ./ci/zig-wrapper
 ```
 
 ## Communication

--- a/ci/zig-wrapper
+++ b/ci/zig-wrapper
@@ -8,7 +8,7 @@ set -xeuo pipefail
 echo "--- which zig"
 ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
 
-echo "--- compile launcher.zig for various architectures"
+echo "--- compile zig-wrapper.zig for various architectures"
 for target in \
     aarch64-linux-gnu.2.19 \
     aarch64-macos-none \
@@ -21,12 +21,12 @@ do
     else
         mcpu=baseline
     fi
-    $ZIG build-exe -fno-emit-bin -target $target -mcpu=$mcpu toolchain/launcher.zig
+    $ZIG build-exe -fno-emit-bin -target $target -mcpu=$mcpu toolchain/zig-wrapper.zig
 done
 
-echo "--- zig fmt --check toolchain/launcher.zig"
-$ZIG fmt --check toolchain/launcher.zig
+echo "--- zig fmt --check toolchain/zig-wrapper.zig"
+$ZIG fmt --check toolchain/zig-wrapper.zig
 
-echo "--- zig test toolchain/launcher.zig"
-# until hermetic_cc_toolchain gets a zig toolchain, run launcher's unit tests here.
-$ZIG test toolchain/launcher.zig
+echo "--- zig test toolchain/zig-wrapper.zig"
+# until hermetic_cc_toolchain gets a zig toolchain, run zig-wrapper's unit tests here.
+$ZIG test toolchain/zig-wrapper.zig

--- a/ci/zig-wrapper-wine64
+++ b/ci/zig-wrapper-wine64
@@ -8,11 +8,11 @@ set -xeuo pipefail
 echo "--- which zig"
 ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
 
-echo "--- test toolchain/launcher.zig via wine64"
+echo "--- test toolchain/zig-wrapper.zig via wine64"
 # ReleaseSafe because of https://github.com/ziglang/zig/issues/14036
 $ZIG test \
     -OReleaseSafe \
     -target x86_64-windows-gnu \
     --test-cmd wine64-stable \
     --test-cmd-bin \
-    toolchain/launcher.zig
+    toolchain/zig-wrapper.zig

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -73,7 +73,10 @@ def _target_macos(gocpu, zigcpu):
             "@platforms//os:macos",
             "@platforms//cpu:{}".format(zigcpu),
         ],
-        tool_paths = {"ld": "ld64.lld"},
+
+        # No longer in upstream zig
+        # // https://github.com/ziglang/zig/commit/0e15205521b9a8c95db3c1714dffe3be1df5cda1
+        ld_zig_subcmd = None,
         artifact_name_patterns = [
             {
                 "category_name": "dynamic_library",
@@ -109,7 +112,7 @@ def _target_windows(gocpu, zigcpu):
             "@platforms//os:windows",
             "@platforms//cpu:{}".format(zigcpu),
         ],
-        tool_paths = {"ld": "ld64.lld"},
+        ld_zig_subcmd = "lld-link",
         artifact_name_patterns = [
             {
                 "category_name": "static_library",
@@ -162,7 +165,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
             "@platforms//cpu:{}".format(zigcpu),
         ],
         libc_constraint = "@zig_sdk//libc:{}".format(glibc_suffix),
-        tool_paths = {"ld": "ld.lld"},
+        ld_zig_subcmd = "ld.lld",
         artifact_name_patterns = [],
     )
 
@@ -190,6 +193,6 @@ def _target_linux_musl(gocpu, zigcpu):
             "@platforms//cpu:{}".format(zigcpu),
         ],
         libc_constraint = "@zig_sdk//libc:musl",
-        tool_paths = {"ld": "ld.lld"},
+        ld_zig_subcmd = "ld.lld",
         artifact_name_patterns = [],
     )


### PR DESCRIPTION
launcher: rename to zig-wrapper + passthrough mode

Also remove `ld64.lld`, since it was removed from zig upstream back in 2021: https://github.com/ziglang/zig/commit/0e15205521b9a8c95db3c1714dffe3be1df5cda1

Until today the "launcher" could do one thing well: set the environment variables and exec the `zig c++` command. However, it was clumsy with other subcommands: `ar`, `ld.lld` do not expect the `-target`. So there was this "special case" for subcommands that are not c++, but, for the sake of consistency, needed to be in the top-level repository.

This change leaves only one sub-command for the target, which truly expects a `-target` flag: `c++`. From now:
- all other sub-commands required for the toolchain are in top-level.
- anything that is not needed for the toolhain can be directly used via zig-wrapper.

This simplifies the launcher quite a bit.
