### PR TITLE
bump zig sdk + simplify zig build workaround

### DIFF
--- a/toolchain/launcher.zig
+++ b/toolchain/launcher.zig
@@ -419,9 +419,8 @@ test "launcher:parseArgs" {
         if (tt.precreate_dir) |dir|
             try tmp.dir.makePath(dir);
 
-        var res = try parseArgs(allocator, tmp.dir, &TestArgIterator{
-            .argv = tt.args,
-        });
+        var argv_it = TestArgIterator{ .argv = tt.args };
+        var res = try parseArgs(allocator, tmp.dir, &argv_it);
 
         switch (tt.want_result) {
             .err => |want_msg| try testing.expectEqualStrings(


### PR DESCRIPTION
Zig notably fixes https://github.com/ziglang/zig/issues/14815; also, by @jacobly in
https://github.com/ziglang/zig/issues/14815#issuecomment-1550874385:

> @motiejus to be clear, this unrelated issue is not affected by a cache
> clear, and can be resolved by simply rerunning the build (and not
> getting very unlucky again).