### PR TITLE
tests: windows fine tuning

### DIFF
--- a/test/glibc_hacks/BUILD
+++ b/test/glibc_hacks/BUILD
@@ -6,6 +6,7 @@ load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary")
 cc_binary(
     name = "main",
     srcs = ["main.c"],
+    tags = ["manual"],
 )
 
 [

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -105,7 +105,9 @@ def _target_windows(gocpu, zigcpu):
         # static library by default. Note that you can still build Windows DLLs if you really want to through the
         # cc_binary rule, see the example in the upstream bazel repo in /examples/windows/dll/.
         supports_dynamic_linker = False,
-        copts = [],
+        # Required to compile Go SDK. Otherwise:
+        #   zig: error: argument unused during compilation: '-mthreads' [-Werror,-Wunused-command-line-argument]
+        copts = ["-Wno-unused-command-line-argument"],
         libc = "mingw",
         bazel_target_cpu = "x64_windows",
         constraint_values = [


### PR DESCRIPTION
With these diffs one can now run

    bazel build //test/...

On Windows.

Tests are not there yet, `target_compatible_with` does not always work as I think it should.