### PR TITLE
Replace `cp` with zig implementation: v2

### DIFF
--- a/rules/BUILD
+++ b/rules/BUILD
@@ -1,4 +1,13 @@
 # Copyright 2023 Uber Technologies, Inc.
 # Licensed under the MIT License
+load("//rules:zig_binary.bzl", "zig_binary")
 
-package(default_visibility = ["//test:__pkg__"])
+package(
+    default_visibility = ["//test:__pkg__"],
+)
+
+zig_binary(
+    name = "cp",
+    src = "cp.zig",
+    visibility = ["//visibility:public"],
+)

--- a/rules/cp.zig
+++ b/rules/cp.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const argv = try std.process.argsAlloc(gpa.allocator());
+    defer std.process.argsFree(gpa.allocator(), argv);
+
+    if (argv.len != 3) return error.InvalidUsage;
+    try std.fs.cwd().copyFile(argv[1], std.fs.cwd(), argv[2], .{});
+}

--- a/rules/platform.bzl
+++ b/rules/platform.bzl
@@ -25,8 +25,8 @@ def _platform_binary_impl(ctx):
     src = ctx.file.src
     ctx.actions.run(
         outputs = [dst],
-        inputs = [src],
-        executable = "cp",
+        inputs = [src, ctx.file._cp],
+        executable = ctx.file._cp.path,
         arguments = [src.path, dst.path],
     )
     return [DefaultInfo(
@@ -45,6 +45,10 @@ _attrs = {
     ),
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+    "_cp": attr.label(
+        default = "//rules:cp",
+        allow_single_file = True,
     ),
 }
 

--- a/rules/zig_binary.bzl
+++ b/rules/zig_binary.bzl
@@ -1,0 +1,35 @@
+def _impl(ctx):
+    dst = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.run(
+        inputs = [ctx.file.src] + ctx.files._zig_sdk,
+        outputs = [dst],
+        executable = ctx.file._zig.path,
+        arguments = [
+            "build-exe",
+            ctx.file.src.short_path,
+            "-femit-bin={}".format(dst.path),
+        ],
+        mnemonic = "ZigBuildExe",
+    )
+    return [DefaultInfo(
+        files = depset([dst]),
+        executable = dst,
+    )]
+
+zig_binary = rule(
+    implementation = _impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = [".zig"],
+        ),
+        "_zig": attr.label(
+            default = "@zig_sdk//:tools/zig-wrapper",
+            allow_single_file = True,
+        ),
+        "_zig_sdk": attr.label(
+            default = "@zig_sdk//:all",
+            allow_files = True,
+        ),
+    },
+    executable = True,
+)


### PR DESCRIPTION
Previously `cp` was invoked with zig:

    zig run cp.zig -- SRC DST

However, this was reverted in 73db33bab01a365a8be01e8586203fc2e95b9f09 due to races in `zig build-exe`, as described in
https://github.com/ziglang/zig/issues/15860

This approach brings back `cp.zig`, but this time the `cp` binary is pre-compiled before invoking it.

That way Bazel will execute `zig build-exe` only once for that target, that way not hitting the race. As a side-effect, the operation will be faster, because `cp` will now be a single binary, as opposed to bringing the whole zig_sdk together.