### PR TITLE
tools/releaser: remove unnecessary paths

### DIFF
--- a/tools/releaser/main.go
+++ b/tools/releaser/main.go
@@ -40,6 +40,7 @@ var (
 	// hashes of already-released versions. Then just hardcode it here.
 	_tagHashes = map[string]string{
 		"v2.0.0-rc2": "40dff82816735e631e8bd51ede3af1c4ed1ad4646928ffb6a0e53e228e55738c",
+		"v2.0.0": "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
 	}
 
 	_boilerplateFiles = []string{
@@ -314,6 +315,12 @@ func makeTgz(w io.Writer, repoRoot string, ref string) (string, error) {
 		"tools/releaser/data/README":    "README",
 	}
 
+	removals := map[string]struct{}{
+		"tools/": struct{}{},
+		"tools/releaser/": struct{}{},
+		"tools/releaser/data/": struct{}{},
+	}
+
 	// Paths to be included to the release
 	cmd := exec.Command(
 		"git",
@@ -362,6 +369,11 @@ func makeTgz(w io.Writer, repoRoot string, ref string) (string, error) {
 		}
 
 		name := hdr.Name
+
+		if _, ok := removals[name]; ok {
+			continue
+		}
+
 		if n, ok := substitutes[name]; ok {
 			name = n
 		}


### PR DESCRIPTION
The current release contains 3 redundant directories:

    $ tar -tf hermetic_cc_toolchain-v2.0.0.tar.gz | grep tools
    tools/
    tools/releaser/
    tools/releaser/data/

This change gets rid of them:

    $ tar -tvf hermetic_cc_toolchain-v99.0.0.tar.gz
    -rw-rw-r-- 0/0            1120 2000-01-01 02:00 LICENSE
    -rw-rw-r-- 0/0             561 2000-01-01 02:00 MODULE.bazel
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/
    -rw-rw-r-- 0/0               0 2000-01-01 02:00 toolchain/BUILD
    -rw-rw-r-- 0/0             407 2000-01-01 02:00 toolchain/BUILD.sdk.bazel
    -rw-rw-r-- 0/0           11180 2000-01-01 02:00 toolchain/defs.bzl
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/libc/
    -rw-rw-r-- 0/0             405 2000-01-01 02:00 toolchain/libc/BUILD
    -rw-rw-r-- 0/0             300 2000-01-01 02:00 toolchain/libc/defs.bzl
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/libc_aware/
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/libc_aware/platform/
    -rw-rw-r-- 0/0             261 2000-01-01 02:00 toolchain/libc_aware/platform/BUILD
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/libc_aware/toolchain/
    -rw-rw-r-- 0/0             264 2000-01-01 02:00 toolchain/libc_aware/toolchain/BUILD
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/platform/
    -rw-rw-r-- 0/0             164 2000-01-01 02:00 toolchain/platform/BUILD
    -rw-rw-r-- 0/0            1493 2000-01-01 02:00 toolchain/platform/defs.bzl
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/private/
    -rw-rw-r-- 0/0               0 2000-01-01 02:00 toolchain/private/BUILD
    -rw-rw-r-- 0/0            2935 2000-01-01 02:00 toolchain/private/cc_toolchains.bzl
    -rw-rw-r-- 0/0            7599 2000-01-01 02:00 toolchain/private/defs.bzl
    drwxrwxr-x 0/0               0 2000-01-01 02:00 toolchain/toolchain/
    -rw-rw-r-- 0/0             167 2000-01-01 02:00 toolchain/toolchain/BUILD
    -rw-rw-r-- 0/0            2049 2000-01-01 02:00 toolchain/toolchain/defs.bzl
    -rw-rw-r-- 0/0           14372 2000-01-01 02:00 toolchain/zig-wrapper.zig
    -rw-rw-r-- 0/0            6010 2000-01-01 02:00 toolchain/zig_toolchain.bzl
    -rw-rw-r-- 0/0             358 2000-01-01 02:00 README
    -rw-rw-r-- 0/0              42 2000-01-01 02:00 WORKSPACE