### PR TITLE
Update slack link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ $ docker run -e CC=/usr/bin/false -ti --rm -v "$PWD:/x" -w /x debian:bookworm-sl
 
 We maintain two channels for comms:
 - Github issues and pull requests.
-- Slack: `#zig` in bazel.slack.com.
+- Slack: `#zig` in bazelbuild.slack.com.
 
 ### Previous Commuications
 


### PR DESCRIPTION
bazel.slack.com -> bazelbuild.slack.com

And I wondered why on earth I could log in from one, but not the other machine.