### PR TITLE
UBSAN: strip paths

### DIFF
--- a/toolchain/zig_toolchain.bzl
+++ b/toolchain/zig_toolchain.bzl
@@ -48,7 +48,7 @@ def _compilation_mode_features(ctx):
                 actions = actions,
                 flag_groups = [
                     flag_group(
-                        flags = ["-g"],
+                        flags = ["-g", "-fsanitize-undefined-strip-path-components=-1"],
                     ),
                 ],
             ),
@@ -77,7 +77,7 @@ def _compilation_mode_features(ctx):
                 actions = actions,
                 flag_groups = [
                     flag_group(
-                        flags = ["-fno-lto"],
+                        flags = ["-fno-lto", "-fsanitize-undefined-strip-path-components=-1"],
                     ),
                 ],
             ),


### PR DESCRIPTION
When a sanitizer (say, UBSAN via `-fsanitize=undefined`) is turned on, `zig cc` will include absolute paths to some header files, making the artifacts non-reproducible.

This commit strips dirnames from such header files.

Fixes #76