### PR TITLE
Enable bzlmod

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,20 +1,16 @@
 # Copyright 2023 Uber Technologies, Inc.
 # Licensed under the MIT License
 
-load("@bazel_gazelle//:def.bzl", "gazelle")
-
 # gazelle:build_file_name BUILD
 # gazelle:prefix github.com/uber/hermetic_cc_toolchain
 # gazelle:exclude tools.go
 
-gazelle(name = "gazelle")
+alias(
+    name = "gazelle",
+    actual = "//tools/gazelle:gazelle",
+)
 
-gazelle(
+alias(
     name = "gazelle-update-repos",
-    args = [
-        "-from_file=go.mod",
-        "-to_macro=repositories.bzl%go_repositories",
-        "-prune",
-    ],
-    command = "update-repos",
+    actual = "//tools/gazelle:gazelle-update-repos",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,9 @@
 module(
     name = "hermetic_cc_toolchain",
-    version = "1.0.1",
+    version = "2.0.0.dev",
 )
 
+bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_go", version = "0.38.1", dev_dependency = True)
 
 go_sdk = use_extension(

--- a/toolchain/ext.bzl
+++ b/toolchain/ext.bzl
@@ -1,0 +1,7 @@
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+
+def _toolchains_impl(ctx):
+    zig_toolchains()
+
+toolchains = module_extension(implementation = _toolchains_impl)

--- a/tools/gazelle/BUILD
+++ b/tools/gazelle/BUILD
@@ -1,0 +1,17 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+    visibility = ["//visibility:public"],
+)
+
+gazelle(
+    name = "gazelle-update-repos",
+    args = [
+        "-from_file=go.mod",
+        "-to_macro=repositories.bzl%go_repositories",
+        "-prune",
+    ],
+    command = "update-repos",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This makes it possible to consume ``hermetic_cc_toolchain`` via ``MODULE.bazel``, in a way that is similar to how it is consumed with ``WORKSPACE``.

This doesn't setup the infrastructure to publish to BCR, so it won't make it available by default. 

This can get used in a ``MODULES.bazel`` like so:

```
bazel_dep(name = "hermetic_cc_toolchain", version = "2.0.0")

toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
use_repo(toolchains, "zig_sdk")

register_toolchains(
    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
    "@zig_sdk//toolchain:darwin_amd64",
    "@zig_sdk//toolchain:darwin_arm64",
    "@zig_sdk//toolchain:windows_amd64",
    "@zig_sdk//toolchain:windows_arm64",
)

archive_override(
    module_name = "hermetic_cc_toolchain",
    urls = [
        "https://github.com/uber/hermetic_cc_toolchain/archive/c602db477e16f1cb10bfbd6c68013604500c4fbe.tar.gz",
    ],
    strip_prefix = "hermetic_cc_toolchain-c602db477e16f1cb10bfbd6c68013604500c4fbe",
    integrity = "sha256-g0WeBysSEkiHEdWmGkUnvTJEGwvqa/N+FDZDNPhUcoM=",
)
```

If it gets published to BCR, the ``archive_override`` would be able to be omitted.

Note: This moves the gazelle definitions into ``//tools/gazelle``, because bzlmod needs to be able to read the ``BUILD`` at the root of the repository, and the dependency on gazelle there would create a hard dependency on gazelle. Moving them down fixes that, but ``bazel //:gazelle`` still works thanks to the aliases.

