### PR TITLE
tests: remove almost all mentions of glibc 2.19

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,7 +69,7 @@ zig_toolchains()
 register_toolchains(
     # if no `--platform` is specified, these toolchains will be used for
     # (linux,darwin,windows)x(amd64,arm64)
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.19",
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
     "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
     "@zig_sdk//toolchain:darwin_amd64",
     "@zig_sdk//toolchain:darwin_arm64",
@@ -77,7 +77,6 @@ register_toolchains(
     "@zig_sdk//toolchain:windows_arm64",
 
     # amd64 toolchains for libc-aware platforms:
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.19",
     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28",
     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31",
     "@zig_sdk//libc_aware/toolchain:linux_amd64_musl",

--- a/ci/zig-utils
+++ b/ci/zig-utils
@@ -11,9 +11,9 @@ ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
 for zigfile in $(git ls-files '*.zig'); do
     echo "--- compile $zigfile for various architectures"
     for target in \
-        aarch64-linux-gnu.2.19 \
+        aarch64-linux-gnu.2.28 \
         aarch64-macos-none \
-        x86_64-linux-gnu.2.19 \
+        x86_64-linux-gnu.2.28 \
         x86_64-macos-none \
         x86_64-windows-gnu
     do

--- a/test/c/BUILD
+++ b/test/c/BUILD
@@ -27,8 +27,7 @@ cc_binary(
     )
     for name, platform, want in [
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl", "non-glibc"),
-        ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19", "glibc_2.19"),
         ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28", "glibc_2.28"),
-        ("linux_amd64", "//platform:linux_amd64", "glibc_2.19"),
+        ("linux_amd64", "//platform:linux_amd64", "glibc_2.28"),
     ]
 ]

--- a/test/cgo/BUILD
+++ b/test/cgo/BUILD
@@ -39,7 +39,7 @@ go_binary(
     )
     for name, platform in [
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl"),
-        ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19"),
+        ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28"),
         ("linux_arm64_musl", "//libc_aware/platform:linux_arm64_musl"),
         ("linux_arm64_gnu.2.28", "//libc_aware/platform:linux_arm64_gnu.2.28"),
         ("darwin_amd64", "//platform:darwin_amd64"),
@@ -54,6 +54,6 @@ go_binary(
     )
     for name, platform, is_arm64 in [
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl", False),
-        ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19", False),
+        ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28", False),
     ]
 ]

--- a/test/glibc_hacks/BUILD
+++ b/test/glibc_hacks/BUILD
@@ -19,7 +19,6 @@ cc_binary(
     )
     for name, platform in [
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl"),
-        ("linux_amd64_gnu.2.19", "//libc_aware/platform:linux_amd64_gnu.2.19"),
         ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28"),
         ("linux_arm64_musl", "//libc_aware/platform:linux_arm64_musl"),
     ]


### PR DESCRIPTION
2.19 is no longer relevant, as Jessie is a long-time EOL.

This will reduce test duration as a side-effect.