### PR TITLE
Releasing hermetic_cc_toolchain v2.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "hermetic_cc_toolchain",
-    version = "2.1.0",
+    version = "2.1.1",
 )
 
 bazel_dep(name = "platforms", version = "0.0.6")

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Add this to your `WORKSPACE`:
 ```
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.0"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.1"
 
 http_archive(
     name = "hermetic_cc_toolchain",
-    sha256 = "892b0dd7aa88c3504a8821e65c44fd22f32c16afab12d89e9942fff492720b37",
+    sha256 = "86ace5cd211d0ae49a729a11afb344843698b64464f2095a776c57ebbdf06698",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),

--- a/examples/rules_cc/WORKSPACE
+++ b/examples/rules_cc/WORKSPACE
@@ -3,11 +3,11 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.0"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.1"
 
 http_archive(
     name = "hermetic_cc_toolchain",
-    sha256 = "892b0dd7aa88c3504a8821e65c44fd22f32c16afab12d89e9942fff492720b37",
+    sha256 = "86ace5cd211d0ae49a729a11afb344843698b64464f2095a776c57ebbdf06698",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),


### PR DESCRIPTION
This is produced by `bazel run //tools/releaser -- -tag v2.1.1`