### PR TITLE
removing unused load

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
-    platform: ["debian11", "ubuntu2004_arm64"]
+    platform: ["debian11", "macos", "macos_arm64", "ubuntu2004_arm64"]
   tasks:
     run_tests:
       name: "Run test module"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
-    platform: ["debian11", "macos", "macos_arm64", "ubuntu2004_arm64"]
+    platform: ["debian11", "ubuntu2004_arm64"]
   tasks:
     run_tests:
       name: "Run test module"

--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -2,7 +2,6 @@
 # Licensed under the MIT License
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary", "platform_test")
 
 go_library(
     name = "cgo_lib",


### PR DESCRIPTION
The unused load caused the CI on Bazel Central repository to fail