### PR TITLE
Testing bzlmod earlier

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,10 +1,11 @@
-bcr_test_module:
-  module_path: "examples/bzlmod"
-  matrix:
-    platform: ["debian11", "macos", "macos_arm64", "ubuntu2004_arm64"]
-  tasks:
-    run_tests:
-      name: "Run test module"
-      platform: ${{ platform }}
-      test_targets:
-        - "//..."
+matrix:
+  platform:
+  - debian11
+  - ubuntu2004_arm64
+  - macos_arm64
+tasks:
+  verify_targets:
+    name: Verify this module can be built as a depenedency of another module
+    platform: ${{ platform }}
+    build_targets:
+    - '@hermetic_cc_toolchain//toolchain/...'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,9 +22,9 @@ steps:
   #         image: "debian:stable"
   #   command: apt-get update && apt-get install --no-install-recommends -y wine64 python3 ca-certificates && ci/zig-utils
   - label: "Test rules_cc example"
-    command: ci/prepare_git && ci/test_example rules_cc
+    command: ci/prepare_git && ci/test_example rules_cc override_repository
   - label: "Test bzlmod example"
-    command: ci/prepare_git && ci/test_example bzlmod
+    command: ci/prepare_git && ci/test_example bzlmod override_module
   - label: "mod-tidy and update-repos"
     command: tools/mod-tidy && git diff --exit-code
 agents:

--- a/ci/test_example
+++ b/ci/test_example
@@ -6,20 +6,21 @@
 set -xeuo pipefail
 
 example=$1
+override_option_name=$2
 
 echo --- setup "$example"
 root=$(git rev-parse --show-toplevel)
 cd "examples/$example"
 
 echo --- "testing examples/$example with hermetic_cc_toolchain pointing to git repository root"
-"$root/tools/bazel" test "--override_repository=hermetic_cc_toolchain=$root" --test_output=errors ...
+"$root/tools/bazel" test "--$override_option_name=hermetic_cc_toolchain=$root" --test_output=errors ...
 
 echo --- "testing examples/$example with hermetic_cc_toolchain pointing to a directory produced by release tarball"
 # generate release tarball and put to temp
 REL=$(mktemp -d); trap 'rm -fr $REL' EXIT; "$root/ci/release_v99"
 tar -vx -C "$REL" -f "$root/hermetic_cc_toolchain-v99.0.0.tar.gz"
 
-"$root/tools/bazel" test "--override_repository=hermetic_cc_toolchain=$REL" --test_output=errors ...
+"$root/tools/bazel" test "--$override_option_name=hermetic_cc_toolchain=$REL" --test_output=errors ...
 
 echo --- "testing examples/$example as is"
 "$root/tools/bazel" test --test_output=errors ...

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 
 bazel_dep(
     name = "hermetic_cc_toolchain",
+    # TODO(zplin): use thel latest released version after we publish it to BCR
     version = "",
 )
 local_path_override(

--- a/tools/releaser/main.go
+++ b/tools/releaser/main.go
@@ -42,6 +42,7 @@ var (
 		"v2.0.0-rc2": "40dff82816735e631e8bd51ede3af1c4ed1ad4646928ffb6a0e53e228e55738c",
 		"v2.0.0":     "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
 		"v2.1.0":     "892b0dd7aa88c3504a8821e65c44fd22f32c16afab12d89e9942fff492720b37",
+		"v2.1.1":     "86ace5cd211d0ae49a729a11afb344843698b64464f2095a776c57ebbdf06698",
 	}
 
 	_boilerplateFiles = []string{

--- a/tools/releaser/main.go
+++ b/tools/releaser/main.go
@@ -351,7 +351,6 @@ func makeTgz(w io.Writer, repoRoot string, ref string) (string, error) {
 		ref,
 		"LICENSE",
 		"toolchain/*",
-		"examples/bzlmod/*",
 
 		// files to be renamed
 		"tools/releaser/data/WORKSPACE",


### PR DESCRIPTION
bzlmod requires a different flag to override external dependencies. We need to parameterize that flag depending on whether an example has bzlmod enabled. With this change, our CI covers the the case of a test module depending on hermetic_cc_toolchain as a `bazel_dep`, pointing to a release archive created from HEAD and running all tests in the test module. Hopefully we can catch issues in our CI, rather than on BCR's CI after a release is cut.

With this change, we no longer run the tests again in BCR's CI and no longer need to include the example in the release archive. We only need to verify that the latest release can be loaded by the [anonymous test module](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md#anonymous-module-test).