### PR TITLE
Strip the zig-builder binary for reproducibility

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -168,6 +168,7 @@ def _zig_repository_impl(repository_ctx):
     compile_cmd = [
         _paths_join("..", "zig"),
         "build-exe",
+        "-fstrip",
         "-mcpu={}".format(_MCPU[host_platform]),
         "-OReleaseSafe",
         "zig-wrapper.zig",


### PR DESCRIPTION
Prior to this, I noticed builds ending up with different digests for the builder fairly often. Stripping those builder binaries manually made them match up; with this patch applied, I was able to have builds be 100% cached when trying 5 times (previously almost every time was a different digest).