### PR TITLE
Fix compile of Go plugin or shared library for Linux ARM64

### DIFF
--- a/test/plugin/BUILD
+++ b/test/plugin/BUILD
@@ -1,0 +1,58 @@
+# Copyright 2023 Uber Technologies, Inc.
+# Licensed under the MIT License
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary")
+
+go_library(
+    name = "plugin_lib",
+    srcs = ["plugin.go"],
+    importpath = "github.com/uber/hermetic_cc_toolchain/test/plugin",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "plugin.so",
+    embed = [":plugin_lib"],
+    linkmode = "plugin",
+    visibility = ["//visibility:private"],
+)
+
+# gazelle:exclude plugin_test.go
+[
+    (
+        platform_binary(
+            name = "plugin_{}.so".format(name),
+            src = ":plugin.so",
+            platform = platform,
+            visibility = ["//visibility:private"],
+        ),
+        go_test(
+            name = "plugin_{}_test".format(name),
+            srcs = ["plugin_test.go"],
+            data = [":plugin_{}.so".format(name)],
+            env = {
+                "PLUGIN_BINARY": "$(rlocationpath :plugin_{}.so)".format(name),
+                "PLUGIN_ELF_MACH": elf_mach,
+            },
+            deps = ["@io_bazel_rules_go//go/runfiles:go_default_library"],
+        ),
+    )
+    for (name, platform, elf_mach) in [
+        ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl", "x86_64"),
+        ("linux_amd64", "//libc_aware/platform:linux_amd64_gnu.2.28", "x86_64"),
+        ("linux_arm64", "//libc_aware/platform:linux_arm64_gnu.2.28", "aarch64"),
+    ]
+]
+
+test_suite(
+    name = "plugin_test",
+    tests = [
+        ":plugin_{}_test".format(name)
+        for name in (
+            "linux_amd64_musl",
+            "linux_amd64",
+            "linux_arm64",
+        )
+    ],
+)

--- a/test/plugin/plugin.go
+++ b/test/plugin/plugin.go
@@ -1,0 +1,16 @@
+// Copyright 2023 Uber Technologies, Inc.
+// Licensed under the MIT License
+//
+// Package main tests that Zig can compile a Go plugin.
+//
+// As of writing, this fails:
+//
+//	$ CGO_ENABLED=1 CC="zig cc" GOOS=linux GOARCH=arm64 go build -linkmode=plugin .
+//	link: ARM64 external linker must be gold (issue #15696, 22040), but is not: zig ld 0.11.0
+//
+// More context: https://github.com/uber/hermetic_cc_toolchain/issues/122
+//
+// This fails, because Go toolchain ask the string "GNU gold" in the output of
+// `$CC -fuse-ld=gold -Wl,--version` when linking the Go plugin.
+// See: https://go.googlesource.com/go/+/8c92897e15d15fbc664cd5a05132ce800cf4017f/src/cmd/link/internal/ld/lib.go#1628
+package main

--- a/test/plugin/plugin_test.go
+++ b/test/plugin/plugin_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Uber Technologies, Inc.
+// Licensed under the MIT License
+
+package main
+
+import (
+	"debug/elf"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+func TestBuild(t *testing.T) {
+	expectedMachineString := os.Getenv("PLUGIN_ELF_MACH")
+	if expectedMachineString == "" {
+		t.Fatalf("Env variable PLUGIN_ELF_MACH not defined")
+	}
+
+	pluginBinaryRPath := os.Getenv("PLUGIN_BINARY")
+
+	pluginBinaryPath, err := runfiles.Rlocation(pluginBinaryRPath)
+	if err != nil {
+		t.Fatalf("can't find runfile %q: %v", pluginBinaryRPath, err)
+	}
+
+	bin, err := elf.Open(pluginBinaryPath)
+	if err != nil {
+		t.Fatalf("can't open file %q: %v", pluginBinaryPath, err)
+	}
+
+	t.Cleanup(func() {
+		if err := bin.Close(); err != nil {
+			t.Errorf("can't close ELF file: %v", err)
+		}
+	})
+
+	if bin.Type != elf.ET_DYN {
+		t.Errorf("ELF type %q incorrect, %q expected", bin.Type, elf.ET_DYN)
+	}
+
+	expectedMachine, _ := map[string]elf.Machine{
+		"x86_64":  elf.EM_X86_64,
+		"aarch64": elf.EM_AARCH64,
+	}[expectedMachineString]
+
+	if bin.Machine != expectedMachine {
+		t.Errorf("ELF machine %q incorrect, %q expected", bin.Machine, expectedMachine)
+	}
+
+	var hasDynamicSection bool
+	for _, s := range bin.Sections {
+		if s.Type == elf.SHT_DYNAMIC {
+			hasDynamicSection = true
+			break
+		}
+	}
+
+	if !hasDynamicSection {
+		t.Error("No dynamic section found in the ELF binary")
+	}
+}

--- a/tools/mod-tidy
+++ b/tools/mod-tidy
@@ -8,5 +8,8 @@ cd "$(git rev-parse --show-toplevel)"
 echo "--- go mod tidy"
 tools/bazel run @go_sdk//:bin/go -- mod tidy "$@"
 
+# Ignore import of @io_bazel_rules_go//go/runfiles
+sed -ri '/github.com\/bazelbuild\/rules_go/d' go.mod go.sum
+
 echo "--- gazelle-update-repos"
 exec tools/bazel run //:gazelle-update-repos


### PR DESCRIPTION
Cross compile a Go plugin for Linux ARM64 requires the command `$CC -fuse-ld=gold -Wl,--version`, executed by the Go toolchain, return the string `GNU gold`.

Using Go **1.20.4**:

```
link: ARM external linker must be gold (issue #15696), but is not: zig ld 0.11.0
```

Using Go **1.21.3**:

```
link: ARM64 external linker must be gold (issue #15696, 22040), but is not: zig ld 0.11.0
```

Building a Go `plugin` library force the Go toolchain to pass in the code [src/cmd/link/internal/ld/lib.go] to link the binary.

See https://go.dev/issue/15696 and https://go.dev/issue/22040 for more details.

Fixes #122

[src/cmd/link/internal/ld/lib.go]: https://go.googlesource.com/go/+/8c92897e15d15fbc664cd5a05132ce800cf4017f/src/cmd/link/internal/ld/lib.go#1628