### PR TITLE
Fix non-existent paths being included in globs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 test --sandbox_default_allow_network=false
 test --test_output=errors
 
+build --incompatible_disallow_empty_glob
 build --verbose_failures
 build --worker_sandboxing
 

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -51,7 +51,6 @@ def target_structs():
     return ret
 
 def _target_macos(gocpu, zigcpu):
-    min_os = "11"
     copts = []
 
     if zigcpu == "aarch64":
@@ -62,9 +61,6 @@ def _target_macos(gocpu, zigcpu):
         zigtarget = "{}-macos-none".format(zigcpu),
         includes = [
             "libunwind/include",
-            # TODO: Define a toolchain for each minimum OS version
-            "libc/include/{}-macos.{}-none".format(zigcpu, min_os),
-            "libc/include/any-macos.{}-any".format(min_os),
             "libc/include/any-macos-any",
         ] + _INCLUDE_TAIL,
         linkopts = ["-Wl,-headerpad_max_install_names"],


### PR DESCRIPTION
I hit this after updating to v2.2.0 where the new zig sdk only includes a `any-macos-any` include folder.

```
 ERROR: Traceback (most recent call last):
	File "/home/runner/.cache/bazel/_bazel_runner/a9f0723b1e9e47cd91eaa9d5188be59d/external/zig_sdk/BUILD", line 11, column 14, in <toplevel>
		declare_files(
	File "/home/runner/.cache/bazel/_bazel_runner/a9f0723b1e9e47cd91eaa9d5188be59d/external/hermetic_cc_toolchain/toolchain/defs.bzl", line 257, column 36, in declare_files
		all_includes = [native.glob(["lib/{}/**".format(i)]) for i in target_config.includes]
Error in glob: glob pattern 'lib/libc/include/x86_64-macos.11-none/**' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: /home/runner/.cache/bazel/_bazel_runner/a9f0723b1e9e47cd91eaa9d5188be59d/external/zig_sdk/BUILD: no such target '@@zig_sdk//:aarch64-linux-musl_cc': target 'aarch64-linux-musl_cc' not declared in package '' defined by /home/runner/.cache/bazel/_bazel_runner/a9f0723b1e9e47cd91eaa9d5188be59d/external/zig_sdk/BUILD (Tip: use `query "@zig_sdk//:*"` to see all the targets in that package)
```