### PR TITLE
MacOS default cache dir: /tmp -> /var/tmp

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,8 @@ build --worker_sandboxing
 
 # TODO: turn this back on when Zig can build CGo (https://github.com/uber/hermetic_cc_toolchain/issues/10)
 #build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
+build --sandbox_add_mount_pair=/tmp
 build --sandbox_add_mount_pair=/var/tmp
 
+build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
 build:darwin_toolchains --extra_toolchains @zig_sdk//toolchain:darwin_amd64,@zig_sdk//toolchain:darwin_arm64

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,6 @@ build --worker_sandboxing
 # TODO: turn this back on when Zig can build CGo (https://github.com/uber/hermetic_cc_toolchain/issues/10)
 #build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
-build --sandbox_add_mount_pair=/tmp
+build --sandbox_add_mount_pair=/var/tmp
 
 build:darwin_toolchains --extra_toolchains @zig_sdk//toolchain:darwin_amd64,@zig_sdk//toolchain:darwin_arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           key: cache-${{ matrix.os }}-${{ hashFiles('.bazelversion', 'toolchain/private/zig_sdk.bzl', '.github/workflows/ci.yaml') }}
           path: |
-            /tmp/zig-cache
+            /var/tmp/zig-cache
             ~/Library/Caches/bazelisk
 
       - uses: actions/cache@v4
@@ -47,7 +47,7 @@ jobs:
         with:
           key: cache-${{ matrix.os }}-${{ hashFiles('.bazelversion', 'toolchain/private/zig_sdk.bzl', '.github/workflows/ci.yaml') }}
           path: |
-            /tmp/zig-cache
+            /var/tmp/zig-cache
             ~/.cache/bazelisk
 
       - run: brew install bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           key: cache-${{ matrix.os }}-${{ hashFiles('.bazelversion', 'toolchain/private/zig_sdk.bzl', '.github/workflows/ci.yaml') }}
           path: |
-            C:\Temp\hermetic_cc_toolchain
+            C:\Temp\zig-cache
             ~\AppData\Local\bazelisk'
 
       - uses: actions/cache@v4
@@ -47,7 +47,7 @@ jobs:
         with:
           key: cache-${{ matrix.os }}-${{ hashFiles('.bazelversion', 'toolchain/private/zig_sdk.bzl', '.github/workflows/ci.yaml') }}
           path: |
-            /var/tmp/zig-cache
+            /tmp/zig-cache
             ~/.cache/bazelisk
 
       - run: brew install bash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ zig_toolchains()
 And this to `.bazelrc` on a Unix-y systems:
 
 ```
+build --sandbox_add_mount_pair=/tmp
 build --sandbox_add_mount_pair=/var/tmp
 ```
 
@@ -70,10 +71,11 @@ Windows:
 build --sandbox_add_mount_pair=C:\Temp
 ```
 
-The directories can be narrowed down to `/var/tmp/zig-cache` and
-`C:\Temp\hermetic_cc_toolchain` respectively if it can be ensured they will be
-created before the invocation of `bazel build`. See [#83][pr-83] for more
-context. If a different place is prefferred for zig cache, set:
+The directories can be narrowed down to `/tmp/zig-cache` (Linux),
+`/var/tmp/zig-cache` (MacOS) and `C:\Temp\zig-cache` respectively
+if it can be ensured they will be created before the invocation of `bazel
+build`. See [#83][pr-83] for more context. If a different place is prefferred
+for zig cache, set:
 
 ```
 build --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=/path/to/cache

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ zig_toolchains()
 And this to `.bazelrc` on a Unix-y systems:
 
 ```
-build --sandbox_add_mount_pair=/tmp
+build --sandbox_add_mount_pair=/var/tmp
 ```
 
 Windows:
@@ -70,7 +70,7 @@ Windows:
 build --sandbox_add_mount_pair=C:\Temp
 ```
 
-The directories can be narrowed down to `/tmp/zig-cache` and
+The directories can be narrowed down to `/var/tmp/zig-cache` and
 `C:\Temp\hermetic_cc_toolchain` respectively if it can be ensured they will be
 created before the invocation of `bazel build`. See [#83][pr-83] for more
 context. If a different place is prefferred for zig cache, set:
@@ -329,7 +329,7 @@ will be accepted.
 
 ### Zig cache location
 
-Currently zig cache is stored in `/tmp/hermetic_cc_toolchain`, so `bazel clean
+Currently zig cache is stored in `/var/tmp/zig-cache`, so `bazel clean
 --expunge` will not clear the zig cache. Zig's cache should be stored somewhere
 in the project's path. It is not clear how to do it.
 

--- a/ci/test
+++ b/ci/test
@@ -5,7 +5,7 @@
 
 set -xeuo pipefail
 
-cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-/tmp/zig-cache}"
+cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-/var/tmp/zig-cache}"
 
 # check a very hermetic setup with a single target. Re-building all of
 # them takes a long time, so using only one. If we ever decide to build all

--- a/ci/test
+++ b/ci/test
@@ -5,7 +5,13 @@
 
 set -xeuo pipefail
 
-cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-/var/tmp/zig-cache}"
+case "$(uname)" in
+    Linux) default_cache_prefix='/tmp/zig-cache' ;;
+    Darwin) default_cache_prefix='/var/tmp/zig-cache' ;;
+    *) default_cache_prefix='C:\Temp\zig-cache' ;;
+esac
+
+cache_prefix="${HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX:-$default_cache_prefix}"
 
 # check a very hermetic setup with a single target. Re-building all of
 # them takes a long time, so using only one. If we ever decide to build all

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -3,9 +3,13 @@
 test --sandbox_default_allow_network=false
 test --test_output=errors
 
+build --incompatible_disallow_empty_glob
 build --verbose_failures
 build --worker_sandboxing
 
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build --sandbox_add_mount_pair=/tmp
 build --sandbox_add_mount_pair=/var/tmp
+
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -7,5 +7,5 @@ build --verbose_failures
 build --worker_sandboxing
 
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build --sandbox_add_mount_pair=/tmp
+build --sandbox_add_mount_pair=/var/tmp
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline

--- a/examples/rules_cc/.bazelrc
+++ b/examples/rules_cc/.bazelrc
@@ -3,9 +3,12 @@
 test --sandbox_default_allow_network=false
 test --test_output=errors
 
+build --incompatible_disallow_empty_glob
 build --verbose_failures
 build --worker_sandboxing
 
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build --sandbox_add_mount_pair=/tmp
 build --sandbox_add_mount_pair=/var/tmp
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline

--- a/examples/rules_cc/.bazelrc
+++ b/examples/rules_cc/.bazelrc
@@ -7,5 +7,5 @@ build --verbose_failures
 build --worker_sandboxing
 
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build --sandbox_add_mount_pair=/tmp
+build --sandbox_add_mount_pair=/var/tmp
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -148,9 +148,13 @@ def _zig_repository_impl(repository_ctx):
     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
     if cache_prefix == "":
         if os == "windows":
-            cache_prefix = "C:\\\\Temp\\\\hermetic_cc_toolchain"
-        else:
+            cache_prefix = "C:\\\\Temp\\\\zig-cache"
+        elif os == "macos":
             cache_prefix = "/var/tmp/zig-cache"
+        elif os == "linux":
+            cache_prefix = "/tmp/zig-cache"
+        else:
+            fail("unknown os: {}".format(os))
 
     repository_ctx.template(
         "tools/zig-wrapper.zig",

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -150,7 +150,7 @@ def _zig_repository_impl(repository_ctx):
         if os == "windows":
             cache_prefix = "C:\\\\Temp\\\\hermetic_cc_toolchain"
         else:
-            cache_prefix = "/tmp/zig-cache"
+            cache_prefix = "/var/tmp/zig-cache"
 
     repository_ctx.template(
         "tools/zig-wrapper.zig",


### PR DESCRIPTION
MacOS has a cronjob that deletes files older than 3 days from /tmp. That's not good for zig cache: https://github.com/ziglang/zig/issues/18763

Switch to /var/tmp, which does not seem to be randomly wiped at runtime.

This breaking change means the next hermetic_cc_toolchain will be v3.0.0.