### PR TITLE
Add wasm32-wasi-musl target

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ use_repo(
     go_deps,
     "com_github_bazelbuild_buildtools",
     "com_github_stretchr_testify",
+    "com_github_tetratelabs_wazero",
 )
 
 toolchains = use_extension("//toolchain:ext.bzl", "toolchains")
@@ -46,4 +47,6 @@ register_toolchains(
     # arm64 toolchains for libc-aware platforms:
     "@zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.28",
     "@zig_sdk//libc_aware/toolchain:linux_arm64_musl",
+    # wasm/wasi toolchains
+    "@zig_sdk//toolchain:wasip1_wasm",
 )

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ register_toolchains(
     "@zig_sdk//toolchain:darwin_arm64",
     "@zig_sdk//toolchain:windows_amd64",
     "@zig_sdk//toolchain:windows_arm64",
+    "@zig_sdk//toolchain:wasip1_wasm",
 )
 ```
 
@@ -291,7 +292,9 @@ Go, the following Go-style toolchain aliases are created:
 |---------------- | -------- |
 |`x86_64`         | `amd64`  |
 |`aarch64`        | `arm64`  |
+|`wasm32`         | `wasm`   |
 |`macos`          | `darwin` |
+|`wasi`           | `wasip1` |
 
 For example, the toolchain `linux_amd64_gnu.2.28` is aliased to
 `x86_64-linux-gnu.2.28`. To find out which toolchains can be registered or

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20230510134650-37bd1811516d
 	github.com/stretchr/testify v1.8.2
+        github.com/tetratelabs/wazero v1.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
+github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/test/c/BUILD
+++ b/test/c/BUILD
@@ -1,5 +1,6 @@
 load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
 
 cc_binary(
     name = "which_libc",
@@ -41,17 +42,19 @@ _WINDOWS_AMD64 = [
             env = {
                 "WANT": want,
                 "BINARY": "$(rlocationpath which_libc_{})".format(name),
+                "EXECUTOR": executor,
             },
             target_compatible_with = compatible_with,
         ),
     )
-    for name, platform, compatible_with, want, tags in [
+    for name, platform, compatible_with, want, tags, executor in [
         (
             "linux_amd64_musl",
             "//libc_aware/platform:linux_amd64_musl",
             _LINUX_AMD64,
             "^linux non-glibc",
             [],
+            "NATIVE",
         ),
         (
             "linux_amd64_gnu.2.28",
@@ -59,6 +62,7 @@ _WINDOWS_AMD64 = [
             _LINUX_AMD64,
             "^linux glibc_2.28",
             [],
+            "NATIVE",
         ),
         (
             "linux_amd64",
@@ -66,6 +70,7 @@ _WINDOWS_AMD64 = [
             _LINUX_AMD64,
             "^linux glibc_2.28",
             [],
+            "NATIVE",
         ),
         (
             "windows_amd64",
@@ -73,6 +78,7 @@ _WINDOWS_AMD64 = [
             _WINDOWS_AMD64,
             "^windows ",
             [],
+            "NATIVE",
         ),
         (
             "darwin_amd64",
@@ -80,6 +86,7 @@ _WINDOWS_AMD64 = [
             _DARWIN_AMD64,
             "^macos non-glibc",
             ["darwin_c"],
+            "NATIVE",
         ),
         (
             "darwin_arm64",
@@ -87,6 +94,15 @@ _WINDOWS_AMD64 = [
             _DARWIN_ARM64,
             "^macos non-glibc",
             ["darwin_c"],
+            "NATIVE",
+        ),
+        (
+            "wasip1_wasm32",
+            "//platform:wasip1_wasm",
+            HOST_CONSTRAINTS,
+            "^wasi non-glibc",
+            [],
+            "WASI",
         ),
     ]
 ]
@@ -96,6 +112,8 @@ go_library(
     srcs = ["c_test.go"],
     deps = [
         "@com_github_stretchr_testify//assert",
+        "@com_github_tetratelabs_wazero//:wazero",
+        "@com_github_tetratelabs_wazero//imports/wasi_snapshot_preview1",
         "@rules_go//go/runfiles",
     ],
 )

--- a/test/c/c_test.go
+++ b/test/c/c_test.go
@@ -1,12 +1,17 @@
 package c_test
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/stretchr/testify/assert"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 func TestYadda(t *testing.T) {
@@ -16,11 +21,36 @@ func TestYadda(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to locate guest binary: %v", err)
 	}
-
-	got, err := exec.Command(binary).CombinedOutput()
+	var got []byte
+	switch os.Getenv("EXECUTOR") {
+	case "NATIVE":
+		got, err = exec.Command(binary).CombinedOutput()
+	case "WASI":
+		got, err = runWasi(binary)
+	default:
+		err = fmt.Errorf("unknown executor: %q", os.Getenv("EXECUTOR"))
+	}
 	if err != nil {
 		t.Fatalf("run %q: %v", binary, err)
 	}
 
 	assert.Regexp(t, string(want), string(got))
+}
+
+func runWasi(binary string) ([]byte, error) {
+	ctx := context.Background()
+	r := wazero.NewRuntime(ctx)
+	defer r.Close(ctx)
+	buf := &bytes.Buffer{}
+	config := wazero.NewModuleConfig().WithStdout(buf).WithStderr(buf).WithArgs("wasi")
+	wasi_snapshot_preview1.MustInstantiate(ctx, r)
+	bin, err := os.ReadFile(binary)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read guest binary: %v", err)
+	}
+	_, err = r.InstantiateWithConfig(ctx, bin, config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create instantiate module: %v", err)
+	}
+	return buf.Bytes(), nil
 }

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -10,6 +10,9 @@
 #elif __linux__
 #include <features.h>
 #define OS "linux"
+#elif __wasi__
+#include <features.h>
+#define OS "wasi"
 #else
 #   error "Unknown compiler!"
 #endif

--- a/toolchain/platform/defs.bzl
+++ b/toolchain/platform/defs.bzl
@@ -14,6 +14,9 @@ def declare_platforms():
             for os in oss:
                 declare_platform(gocpu, zigcpu, bzlos, os)
 
+    # We can support GOARCH=wasm32 after https://github.com/golang/go/issues/63131
+    declare_platform("wasm", "wasm32", "wasi", "wasip1")
+
 def declare_libc_aware_platforms():
     # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventions
     # with libc specified

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -48,6 +48,7 @@ def target_structs():
         ret.append(_target_linux_musl(gocpu, zigcpu))
         for glibc in _GLIBCS:
             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
+    ret.append(_target_wasm())
     return ret
 
 def _target_macos(gocpu, zigcpu):
@@ -197,5 +198,27 @@ def _target_linux_musl(gocpu, zigcpu):
         ],
         libc_constraint = "@zig_sdk//libc:musl",
         ld_zig_subcmd = "ld.lld",
+        artifact_name_patterns = [],
+    )
+
+def _target_wasm():
+    return struct(
+        gotarget = "wasip1_wasm",
+        zigtarget = "wasm32-wasi-musl",
+        includes = [
+            "libc/include/wasm-wasi-musl",
+            "libc/wasi",
+        ] + _INCLUDE_TAIL,
+        linkopts = [],
+        dynamic_library_linkopts = [],
+        supports_dynamic_linker = False,
+        copts = [],
+        libc = "musl",
+        bazel_target_cpu = "wasm32",
+        constraint_values = [
+            "@platforms//os:wasi",
+            "@platforms//cpu:wasm32",
+        ],
+        ld_zig_subcmd = "wasm-ld",
         artifact_name_patterns = [],
     )

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -279,11 +279,11 @@ fn getRunMode(self_exe: []const u8, self_base_noexe: []const u8) error{BadParent
     var it = mem.split(u8, triple, "-");
 
     const arch = it.next() orelse return error.BadParent;
-    if (mem.indexOf(u8, "aarch64,x86_64", arch) == null)
+    if (mem.indexOf(u8, "aarch64,x86_64,wasm32", arch) == null)
         return error.BadParent;
 
     const got_os = it.next() orelse return error.BadParent;
-    if (mem.indexOf(u8, "linux,macos,windows", got_os) == null)
+    if (mem.indexOf(u8, "linux,macos,windows,wasi", got_os) == null)
         return error.BadParent;
 
     // ABI triple is too much of a moving target


### PR DESCRIPTION
I would like to be able to compile wasm/wasi with zig + bazel. This adds
a toolchain to be able to do so. Wasm/wasi is a pretty rapidly changing
space, but I've choosen the most specific naming that I could (WASI
preview 1).

I've confirmed this works by running the compiled binary with [wasmtime](https://wasmtime.dev/),
a popular wasm/wasi runtime.

```shell
bazel run --run_under=wasmtime //test/c:which_libc_wasip1_wasm
```
