### PR TITLE
test/cgo: cleanup

### DIFF
--- a/rules/platform.bzl
+++ b/rules/platform.bzl
@@ -61,14 +61,6 @@ platform_binary = rule(
     executable = True,
 )
 
-# wrap a single test target and build it for the specified platform.
-platform_test = rule(
-    implementation = _platform_binary_impl,
-    cfg = _platform_transition,
-    attrs = _attrs,
-    test = True,
-)
-
 ## Copied from https://github.com/bazelbuild/bazel-skylib/blob/1.4.1/lib/paths.bzl#L22
 def _paths_basename(p):
     return p.rpartition("/")[-1]

--- a/test/cgo/BUILD
+++ b/test/cgo/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the MIT License
 
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary", "platform_test")
+load("@hermetic_cc_toolchain//rules:platform.bzl", "platform_binary")
 
 go_library(
     name = "cgo_lib",
@@ -23,16 +23,6 @@ go_binary(
     embed = [":cgo_lib"],
     visibility = ["//visibility:public"],
 )
-
-_LINUX_AMD64 = [
-    "@platforms//os:linux",
-    "@platforms//cpu:x86_64",
-]
-
-_WINDOWS_AMD64 = [
-    "@platforms//os:windows",
-    "@platforms//cpu:x86_64",
-]
 
 [
     (


### PR DESCRIPTION
also remove `platform_test`, that is no longer used.