### PR TITLE
Move toolchain registrations to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,3 +22,20 @@ build:macos --build_tag_filters=-darwin_c
 
 test --sandbox_default_allow_network=false
 test --test_output=errors
+
+# if no `--platform` is specified, these toolchains will be used for
+# (linux,darwin,windows)x(amd64,arm64)
+build --extra_toolchains @zig_sdk//toolchain:linux_amd64_gnu.2.28
+build --extra_toolchains @zig_sdk//toolchain:linux_arm64_gnu.2.28
+build --extra_toolchains @zig_sdk//toolchain:windows_amd64
+build --extra_toolchains @zig_sdk//toolchain:windows_arm64
+
+# amd64 toolchains for libc-aware platforms:
+build --extra_toolchains @zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28
+build --extra_toolchains @zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31
+build --extra_toolchains @zig_sdk//libc_aware/toolchain:linux_amd64_musl
+# arm64 toolchains for libc-aware platforms:
+build --extra_toolchains @zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.28
+build --extra_toolchains @zig_sdk//libc_aware/toolchain:linux_arm64_musl
+# wasm/wasi toolchains
+build --extra_toolchains @zig_sdk//toolchain:wasip1_wasm

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,22 +31,3 @@ use_repo(
 
 toolchains = use_extension("//toolchain:ext.bzl", "toolchains")
 use_repo(toolchains, "zig_sdk")
-
-register_toolchains(
-    # if no `--platform` is specified, these toolchains will be used for
-    # (linux,darwin,windows)x(amd64,arm64)
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//toolchain:windows_amd64",
-    "@zig_sdk//toolchain:windows_arm64",
-
-    # amd64 toolchains for libc-aware platforms:
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31",
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_musl",
-    # arm64 toolchains for libc-aware platforms:
-    "@zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//libc_aware/toolchain:linux_arm64_musl",
-    # wasm/wasi toolchains
-    "@zig_sdk//toolchain:wasip1_wasm",
-)


### PR DESCRIPTION
After the migration to bzlmod, the toolchain registration for the module's code and tests ended up in the MODULE.bazel itself, which means it gets carried across to module users. This means it's not possible to choose which toolchains are wanted, and defeats some of the use cases mentioned in README.md.

Moving this to .bazelrc is a workaround that restores the original (pre-bzlmod) behavior.

Fixes #181