### PR TITLE
feat: use .wasm artifact name extension

### DIFF
--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -220,5 +220,17 @@ def _target_wasm():
             "@platforms//cpu:wasm32",
         ],
         ld_zig_subcmd = "wasm-ld",
-        artifact_name_patterns = [],
+        # .wasm extension supported in bazel >= 6.4.0
+        artifact_name_patterns = [
+            {
+                "category_name": "dynamic_library",
+                "prefix": "",
+                "extension": ".wasm",
+            },
+            {
+                "category_name": "executable",
+                "prefix": "",
+                "extension": ".wasm",
+            },
+        ],
     )


### PR DESCRIPTION
I added support for the `.wasm` extension to bazel last year and I figured it'd be a slightly nicity improvement when targetting wasm.