### PR TITLE
Append username to the default tmp directory

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -147,12 +147,16 @@ def _zig_repository_impl(repository_ctx):
 
     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
     if cache_prefix == "":
+        # Append the username when available to reduce risks of conflict.
+        username = repository_ctx.os.environ.get("USER", "")
+        if username:
+            username = "-" + username
         if os == "windows":
-            cache_prefix = "C:\\\\Temp\\\\zig-cache"
+            cache_prefix = "C:\\\\Temp\\\\zig-cache" + username
         elif os == "macos":
-            cache_prefix = "/var/tmp/zig-cache"
+            cache_prefix = "/var/tmp/zig-cache" + username
         elif os == "linux":
-            cache_prefix = "/tmp/zig-cache"
+            cache_prefix = "/tmp/zig-cache" + username
         else:
             fail("unknown os: {}".format(os))
 


### PR DESCRIPTION
When two people build code on the same machine, there can be a collision. The second person may not be able to write to zig-cache if it was created by someone else. When it happens, the error message is quite confusing (see `_compile_failed` variable).

With this commit, each user should get a different directory by default. It's still possible to change the default using `HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX`.