### PR TITLE
Mark toolchains registered in our MODULE.bazel as a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,4 +49,7 @@ register_toolchains(
     "@zig_sdk//libc_aware/toolchain:linux_arm64_musl",
     # wasm/wasi toolchains
     "@zig_sdk//toolchain:wasip1_wasm",
+
+    # These toolchains are only registered locally.
+    dev_dependency = True,
 )

--- a/ci/release
+++ b/ci/release
@@ -12,12 +12,6 @@ TAG=$(git -c 'versionsort.suffix=-rc' tag --sort=v:refname | tail -1)
 tools/bazel run //tools/releaser -- -tag "$TAG" -skipBranchCheck
 
 >&2 echo "--- git diff :git:"
-if [ "$GITHUB_EVENT_NAME" = "pull_request" ]
-then
-    # Don't fail on diff in a pull request
-    git diff
-else
-    git diff --exit-code
-fi
+git diff
 
 >&2 echo "OK :white_check_mark:"

--- a/ci/release
+++ b/ci/release
@@ -12,6 +12,12 @@ TAG=$(git -c 'versionsort.suffix=-rc' tag --sort=v:refname | tail -1)
 tools/bazel run //tools/releaser -- -tag "$TAG" -skipBranchCheck
 
 >&2 echo "--- git diff :git:"
-git diff --exit-code
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]
+then
+    # Don't fail on diff in a pull request
+    git diff
+else
+    git diff --exit-code
+fi
 
 >&2 echo "OK :white_check_mark:"


### PR DESCRIPTION
Mark toolchains registered in this repo as a dev dependency. Users will need to register their own toolchains, like they do in WORKSPACE.

Fixes #181.