### PR TITLE
feat: create cc_toolchains for multiple exec platforms

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,26 +30,30 @@ use_repo(
 )
 
 toolchains = use_extension("//toolchain:ext.bzl", "toolchains")
-use_repo(toolchains, "zig_sdk")
+use_repo(toolchains, "amd64-linux-zig_sdk", "aarch64-linux-zig_sdk")
 
-register_toolchains(
+
+[register_toolchains(
     # if no `--platform` is specified, these toolchains will be used for
     # (linux,darwin,windows)x(amd64,arm64)
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//toolchain:windows_amd64",
-    "@zig_sdk//toolchain:windows_arm64",
+    "@{}-zig_sdk//toolchain:linux_amd64_gnu.2.28".format(h),
+    "@{}-zig_sdk//toolchain:linux_arm64_gnu.2.28".format(h),
+    "@{}-zig_sdk//toolchain:windows_amd64".format(h),
+    "@{}-zig_sdk//toolchain:windows_arm64".format(h),
 
-    # amd64 toolchains for libc-aware platforms:
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31",
-    "@zig_sdk//libc_aware/toolchain:linux_amd64_musl",
+     # amd64 toolchains for libc-aware platforms:
+    "@{}-zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.28".format(h),
+    "@{}-zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.31".format(h),
+    "@{}-zig_sdk//libc_aware/toolchain:linux_amd64_musl".format(h),
     # arm64 toolchains for libc-aware platforms:
-    "@zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//libc_aware/toolchain:linux_arm64_musl",
+    "@{}-zig_sdk//libc_aware/toolchain:linux_arm64_gnu.2.28".format(h),
+    "@{}-zig_sdk//libc_aware/toolchain:linux_arm64_musl".format(h),
     # wasm/wasi toolchains
-    "@zig_sdk//toolchain:wasip1_wasm",
+    "@{}-zig_sdk//toolchain:wasip1_wasm".format(h),
 
     # These toolchains are only registered locally.
     dev_dependency = True,
-)
+)for h in (
+    "amd64-linux",
+    "aarch64-linux",
+    )]

--- a/rules/platform.bzl
+++ b/rules/platform.bzl
@@ -4,7 +4,7 @@
 def _platform_transition_impl(settings, attr):
     _ignore = settings
     return {
-        "//command_line_option:platforms": "@zig_sdk{}".format(attr.platform),
+        "//command_line_option:platforms": "@amd64-linux-zig_sdk{}".format(attr.platform),
     }
 
 _platform_transition = transition(

--- a/rules/zig_binary.bzl
+++ b/rules/zig_binary.bzl
@@ -32,11 +32,11 @@ zig_binary = rule(
             allow_single_file = [".zig"],
         ),
         "_zig": attr.label(
-            default = "@zig_sdk//:tools/zig-wrapper",
+            default = "@amd64-linux-zig_sdk//:tools/zig-wrapper",
             allow_single_file = True,
         ),
         "_zig_sdk": attr.label(
-            default = "@zig_sdk//:all",
+            default = "@amd64-linux-zig_sdk//:all",
             allow_files = True,
         ),
         "_macos_constraint": attr.label(

--- a/toolchain/BUILD.sdk.bazel
+++ b/toolchain/BUILD.sdk.bazel
@@ -16,3 +16,13 @@ declare_cc_toolchains(
     os = {os},
     zig_sdk_path = {zig_sdk_path},
 )
+
+alias(
+    name = "exec_os",
+    actual = "@platforms//os:{exec_os}",
+)
+
+alias(
+    name = "exec_cpu",
+    actual = "@platforms//cpu:{exec_cpu}",
+)

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -57,10 +57,12 @@ After commenting on the issue, `rm -fr {cache_prefix}` and re-run your command.
 """
 
 def toolchains(
+        exec,
         version = VERSION,
         url_formats = [],
         host_platform_sha256 = HOST_PLATFORM_SHA256,
-        host_platform_ext = _HOST_PLATFORM_EXT):
+        host_platform_ext = _HOST_PLATFORM_EXT,
+        ):
     """
         Download zig toolchain and declare bazel toolchains.
         The platforms are not registered automatically, that should be done by
@@ -78,29 +80,40 @@ def toolchains(
         url_formats = [mirror_format, original_format]
 
     zig_repository(
-        name = "zig_sdk",
+        name = "{}-zig_sdk".format(exec),
         version = version,
         url_formats = url_formats,
         host_platform_sha256 = host_platform_sha256,
         host_platform_ext = host_platform_ext,
+        exec = exec,
     )
 
 def _quote(s):
     return "'" + s.replace("'", "'\\''") + "'"
 
 def _zig_repository_impl(repository_ctx):
-    arch = repository_ctx.os.arch
-    if arch == "amd64":
-        arch = "x86_64"
+    arch_os = repository_ctx.attr.exec.split("-")
+    exec_arch = arch_os[0]
+    exec_os = arch_os[1]
+    host_os = repository_ctx.os.name
+    host_arch = repository_ctx.os.arch
+    if exec_arch == "amd64":
+        exec_arch = "x86_64"
+    if host_arch == "amd64":
+        host_arch = "x86_64"
 
-    os = repository_ctx.os.name.lower()
-    if os.startswith("mac os"):
-        os = "macos"
+    # os = repository_ctx.os.name.lower()
+    if exec_os.startswith("mac os"):
+        exec_os = "macos"
+    if host_os.startswith("mac os"):
+        host_os = "macos"
+    if exec_os.startswith("windows"):
+        exec_os = "windows"
+    if host_os.startswith("windows"):
+        host_os = "windows"
 
-    if os.startswith("windows"):
-        os = "windows"
-
-    host_platform = "{}-{}".format(os, arch)
+    host_platform = "{}-{}".format(host_os, host_arch)
+    exec_platform = "{}-{}".format(exec_os, exec_arch)
 
     zig_sha256 = repository_ctx.attr.host_platform_sha256[host_platform]
     zig_ext = repository_ctx.attr.host_platform_ext[host_platform]
@@ -108,6 +121,11 @@ def _zig_repository_impl(repository_ctx):
         "_ext": zig_ext,
         "version": repository_ctx.attr.version,
         "host_platform": host_platform,
+    }
+    format_vars_exec = {
+        "_ext": repository_ctx.attr.host_platform_ext[exec_platform],
+        "version": repository_ctx.attr.version,
+        "host_platform": exec_platform,
     }
 
     # Fetch Label dependencies before doing download/extract.
@@ -133,7 +151,9 @@ def _zig_repository_impl(repository_ctx):
             executable = False,
             substitutions = {
                 "{zig_sdk_path}": _quote("external/zig_sdk"),
-                "{os}": _quote(os),
+                "{os}": _quote(exec_os),
+                "{exec_os}": exec_os,
+                "{exec_cpu}": exec_arch,
             },
         )
 
@@ -147,14 +167,14 @@ def _zig_repository_impl(repository_ctx):
 
     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
     if cache_prefix == "":
-        if os == "windows":
+        if host_os == "windows":
             cache_prefix = "C:\\\\Temp\\\\zig-cache"
-        elif os == "macos":
+        elif host_os == "macos":
             cache_prefix = "/var/tmp/zig-cache"
-        elif os == "linux":
+        elif host_os == "linux":
             cache_prefix = "/tmp/zig-cache"
         else:
-            fail("unknown os: {}".format(os))
+            fail("unknown os: {}".format(host_os))
 
     repository_ctx.template(
         "tools/zig-wrapper.zig",
@@ -169,12 +189,13 @@ def _zig_repository_impl(repository_ctx):
         "ZIG_LOCAL_CACHE_DIR": cache_prefix,
         "ZIG_GLOBAL_CACHE_DIR": cache_prefix,
     }
+
     compile_cmd = [
         _paths_join("..", "zig"),
         "build-exe",
         "-target",
-        _TARGET_MCPU[host_platform][0],
-        "-mcpu={}".format(_TARGET_MCPU[host_platform][1]),
+        _TARGET_MCPU[exec_platform][0],
+        "-mcpu={}".format(_TARGET_MCPU[exec_platform][1]),
         "-fstrip",
         "-OReleaseSafe",
         "zig-wrapper.zig",
@@ -213,12 +234,21 @@ def _zig_repository_impl(repository_ctx):
     if not zig_wrapper_success:
         fail(zig_wrapper_err_msg)
 
-    exe = ".exe" if os == "windows" else ""
+    exe = ".exe" if exec_os == "windows" else ""
     for t in _BUILTIN_TOOLS:
         repository_ctx.symlink("tools/zig-wrapper{}".format(exe), "tools/{}{}".format(t, exe))
 
+    urls = [uf.format(**format_vars_exec) for uf in repository_ctx.attr.url_formats]
+
+    repository_ctx.download_and_extract(
+        auth = use_netrc(read_user_netrc(repository_ctx), urls, {}),
+        url = urls,
+        stripPrefix = "zig-{host_platform}-{version}/".format(**format_vars_exec),
+        sha256 = repository_ctx.attr.host_platform_sha256[exec_platform],
+    )
+
     for target_config in target_structs():
-        tool_path = zig_tool_path(os).format(
+        tool_path = zig_tool_path(exec_os).format(
             zig_tool = "c++",
             zigtarget = target_config.zigtarget,
         )
@@ -230,6 +260,7 @@ zig_repository = repository_rule(
         "host_platform_sha256": attr.string_dict(),
         "url_formats": attr.string_list(allow_empty = False),
         "host_platform_ext": attr.string_dict(),
+        "exec": attr.string(),
     },
     environ = ["HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX"],
     implementation = _zig_repository_impl,

--- a/toolchain/ext.bzl
+++ b/toolchain/ext.bzl
@@ -1,6 +1,19 @@
 load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
+_HOSTS = (
+    "amd64-linux",
+    "aarch64-linux",
+)
+
 def _toolchains_impl(ctx):
-    zig_toolchains()
+    for EXEC_HOST in _HOSTS:
+        zig_toolchains(exec = EXEC_HOST)
+
+
+    return ctx.extension_metadata(
+        root_module_direct_deps= ["{}-zig_sdk".format(h) for h in _HOSTS],
+        root_module_direct_dev_deps=[],
+        )
+
 
 toolchains = module_extension(implementation = _toolchains_impl)

--- a/toolchain/platform/defs.bzl
+++ b/toolchain/platform/defs.bzl
@@ -28,7 +28,7 @@ def declare_libc_aware_platforms():
                 "linux",
                 "linux",
                 suffix = "_{}".format(libc),
-                extra_constraints = ["@zig_sdk//libc:{}".format(libc)],
+                extra_constraints = ["//libc:{}".format(libc)],
             )
 
 def declare_platform(gocpu, zigcpu, bzlos, os, suffix = "", extra_constraints = []):

--- a/toolchain/private/cc_toolchains.bzl
+++ b/toolchain/private/cc_toolchains.bzl
@@ -3,7 +3,6 @@ load("@hermetic_cc_toolchain//toolchain:zig_toolchain.bzl", "zig_cc_toolchain_co
 
 def declare_cc_toolchains(os, zig_sdk_path):
     exe = ".exe" if os == "windows" else ""
-
     for target_config in target_structs():
         gotarget = target_config.gotarget
         zigtarget = target_config.zigtarget
@@ -59,13 +58,13 @@ def declare_cc_toolchains(os, zig_sdk_path):
             name = zigtarget + "_cc",
             toolchain_identifier = zigtarget + "-toolchain",
             toolchain_config = ":%s_cc_config" % zigtarget,
-            all_files = "@zig_sdk//:%s_all_files" % zigtarget,
-            ar_files = "@zig_sdk//:%s_ar_files" % zigtarget,
-            compiler_files = "@zig_sdk//:%s_compiler_files" % zigtarget,
-            linker_files = "@zig_sdk//:%s_linker_files" % zigtarget,
-            dwp_files = "@zig_sdk//:empty",
-            objcopy_files = "@zig_sdk//:empty",
-            strip_files = "@zig_sdk//:empty",
+            all_files = "//:{}_all_files".format(zigtarget),
+            ar_files = "//:{}_ar_files".format(zigtarget),
+            compiler_files = "//:{}_compiler_files".format(zigtarget),
+            linker_files = "//:{}_linker_files".format(zigtarget),
+            dwp_files = "//:empty",
+            objcopy_files = "//:empty",
+            strip_files = "//:empty",
             supports_param_files = 0,
             visibility = ["//visibility:private"],
         )

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -168,7 +168,7 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
             "@platforms//os:linux",
             "@platforms//cpu:{}".format(zigcpu),
         ],
-        libc_constraint = "@zig_sdk//libc:{}".format(glibc_suffix),
+        libc_constraint = "//libc:{}".format(glibc_suffix),
         ld_zig_subcmd = "ld.lld",
         artifact_name_patterns = [],
     )
@@ -196,7 +196,7 @@ def _target_linux_musl(gocpu, zigcpu):
             "@platforms//os:linux",
             "@platforms//cpu:{}".format(zigcpu),
         ],
-        libc_constraint = "@zig_sdk//libc:musl",
+        libc_constraint = "//libc:musl",
         ld_zig_subcmd = "ld.lld",
         artifact_name_patterns = [],
     )

--- a/toolchain/toolchain/defs.bzl
+++ b/toolchain/toolchain/defs.bzl
@@ -10,7 +10,7 @@ def declare_toolchains():
         # only selected if the specific libc variant is selected.
         extra_constraints = []
         if hasattr(target_config, "libc_constraint"):
-            extra_constraints = ["@zig_sdk//libc:unconstrained"]
+            extra_constraints = ["//libc:unconstrained"]
 
         _declare_toolchain(gotarget, zigtarget, target_config.constraint_values + extra_constraints)
 
@@ -30,17 +30,17 @@ def _declare_toolchain(gotarget, zigtarget, target_compatible_with):
     # Go convention: amd64/arm64, linux/darwin
     native.toolchain(
         name = gotarget,
-        exec_compatible_with = None,
+        exec_compatible_with = ["//:exec_os",  "//:exec_cpu"],
         target_compatible_with = target_compatible_with,
-        toolchain = "@zig_sdk//:%s_cc" % zigtarget,
+        toolchain = "//:{}_cc".format(zigtarget),
         toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     )
 
     # Zig convention: x86_64/aarch64, linux/macos
     native.toolchain(
         name = zigtarget,
-        exec_compatible_with = None,
+        exec_compatible_with = ["//:exec_os", "//:exec_cpu"],
         target_compatible_with = target_compatible_with,
-        toolchain = "@zig_sdk//:%s_cc" % zigtarget,
+        toolchain = "//:{}_cc".format(zigtarget),
         toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     )


### PR DESCRIPTION
This change aims to allow hermetic_cc_toolchain to create toolchains for multiple exec platforms. It now generates repositories of the format {exec}-zig_sdk and registers each toolchain to only be exec_compatible_with those specific platform constraints.

I want this PR to be a WIP as we discuss how we want this to look and if you're happy with it's general flow.

This is an attempt at fixing https://github.com/uber/hermetic_cc_toolchain/issues/148 

So far I have tested that my local client (mac) can build c code using the toolchains registered on a `x86_64` remote executor and have seen success. It'll will be hard for me to test every combination; but I will be able to local (x86_64) -> remote (arm64) tests as well.
