### PR TITLE
add cwd to cache prefix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,10 +8,6 @@ build --worker_sandboxing
 
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
 
-build:linux --sandbox_add_mount_pair=/tmp
-build:macos --sandbox_add_mount_pair=/var/tmp
-build:windows --sandbox_add_mount_pair=C:\Temp
-
 build:macos_toolchains --extra_toolchains @zig_sdk//toolchain:darwin_amd64,@zig_sdk//toolchain:darwin_arm64
 build:macos_toolchains --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:macos_toolchains --build_tag_filters=

--- a/README.md
+++ b/README.md
@@ -62,20 +62,14 @@ And this to `.bazelrc` on a Unix-y systems:
 
 ```
 common --enable_platform_specific_config
-build:linux --sandbox_add_mount_pair=/tmp
-build:macos --sandbox_add_mount_pair=/var/tmp
-build:windows --sandbox_add_mount_pair=C:\Temp
 ```
 
-The directories can be narrowed down to `/tmp/zig-cache` (Linux),
-`/var/tmp/zig-cache` (MacOS) and `C:\Temp\zig-cache` respectively
-if it can be ensured they will be created before the invocation of `bazel
-build`. See [#83][pr-83] for more context. If a different place is preferred
-for zig cache, set:
+The default zig cache location is within `./zig-cache` in the workspace root. If
+a different path is preferred for zig cache, set it. (It is always resolved
+against the workspace root):
 
 ```
-build --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=/path/to/cache
-build --sandbox_add_mount_pair=/path/to/cache
+build --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=path/to/cache
 ```
 
 The snippets above will download the zig toolchain and make the bazel
@@ -441,6 +435,5 @@ On a more practical note:
 [subset]: https://en.wikipedia.org/wiki/Subset
 [universal-headers]: https://github.com/ziglang/universal-headers
 [go-monorepo]: https://www.uber.com/blog/go-monorepo-bazel/
-[pr-83]: https://github.com/uber/hermetic_cc_toolchain/issues/83
 [pr-10]: https://github.com/uber/hermetic_cc_toolchain/issues/10
 [examples]: https://github.com/uber/hermetic_cc_toolchain/tree/main/examples

--- a/examples/bzlmod/.bazelrc
+++ b/examples/bzlmod/.bazelrc
@@ -9,9 +9,5 @@ build --verbose_failures
 build --worker_sandboxing
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
 
-build:linux --sandbox_add_mount_pair=/tmp
-build:macos --sandbox_add_mount_pair=/var/tmp
-build:windows --sandbox_add_mount_pair=C:\Temp
-
 test --sandbox_default_allow_network=false
 test --test_output=errors

--- a/examples/rules_cc/.bazelrc
+++ b/examples/rules_cc/.bazelrc
@@ -9,9 +9,6 @@ build --verbose_failures
 build --worker_sandboxing
 build --experimental_output_directory_naming_scheme=diff_against_dynamic_baseline
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:linux --sandbox_add_mount_pair=/tmp
-build:macos --sandbox_add_mount_pair=/var/tmp
-build:windows --sandbox_add_mount_pair=C:\Temp
 
 test --sandbox_default_allow_network=false
 test --test_output=errors

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -192,7 +192,8 @@ def _zig_repository_impl(repository_ctx):
     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
     if cache_prefix == "":
         if host_os == "windows" or host_os == "macos" or host_os == "linux":
-            cache_prefix = "zig-cache"
+            # Use a shared cache directory in the execroot for all platforms
+            cache_prefix = "../../../zig_cache"
         else:
             fail("unknown os: {}".format(host_os))
 

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -191,12 +191,8 @@ def _zig_repository_impl(repository_ctx):
 
     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
     if cache_prefix == "":
-        if host_os == "windows":
-            cache_prefix = "C:\\\\Temp\\\\zig-cache"
-        elif host_os == "macos":
-            cache_prefix = "/var/tmp/zig-cache"
-        elif host_os == "linux":
-            cache_prefix = "/tmp/zig-cache"
+        if host_os == "windows" or host_os == "macos" or host_os == "linux":
+            cache_prefix = "zig-cache"
         else:
             fail("unknown os: {}".format(host_os))
 

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -63,7 +63,6 @@ const EXE = switch (builtin.target.os.tag) {
     .windows => ".exe",
     else => "",
 };
-
 const CACHE_DIR = "{HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX}";
 
 const usage =
@@ -208,6 +207,7 @@ fn parseArgs(
         );
     };
 
+    const zig_cache_dir = try fs.path.join(arena, &[_][]const u8{ cwd.realpathAlloc(arena, ".") catch unreachable, CACHE_DIR });
     const zig_lib_dir = try fs.path.join(arena, &[_][]const u8{ root, "lib" });
     const zig_exe = try fs.path.join(
         arena,
@@ -218,8 +218,8 @@ fn parseArgs(
         return parseFatal(arena, "error getting env: {s}", .{@errorName(err)});
 
     try env.put("ZIG_LIB_DIR", zig_lib_dir);
-    try env.put("ZIG_LOCAL_CACHE_DIR", CACHE_DIR);
-    try env.put("ZIG_GLOBAL_CACHE_DIR", CACHE_DIR);
+    try env.put("ZIG_LOCAL_CACHE_DIR", zig_cache_dir);
+    try env.put("ZIG_GLOBAL_CACHE_DIR", zig_cache_dir);
 
     // args is the path to the zig binary and args to it.
     var args = ArrayListUnmanaged([]const u8){};

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -207,7 +207,13 @@ fn parseArgs(
         );
     };
 
-    const zig_cache_dir = try fs.path.join(arena, &[_][]const u8{ cwd.realpathAlloc(arena, ".") catch unreachable, CACHE_DIR });
+    const zig_cache_dir = if (CACHE_DIR[0] == sep[0])
+        CACHE_DIR
+    else
+        try fs.path.join(arena, &[_][]const u8{
+            cwd.realpathAlloc(arena, ".") catch unreachable,
+            CACHE_DIR,
+        });
     const zig_lib_dir = try fs.path.join(arena, &[_][]const u8{ root, "lib" });
     const zig_exe = try fs.path.join(
         arena,


### PR DESCRIPTION
Caveat: I don't know what I'm doing with zig. The zig code was mostly code assistant-generated.

I don't think this is a breaking change, but if somebody does rely on the cache location, they can set the `HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX` to one of the prior values (`/tmp`, `/var/tmp`, `C:\Temp`) to maintain same behavior.

## Test Plan
I added a debug print statement for the `zig_cache_dir` variable to see its value.
I tried the following test cases: 
| Input:`HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX` | Output: `zig_cache_dir` (Printed value) |
|--------|--------|
| unset | `<workspace root>/zig-cache` |
| `/tmp/my-test-cache` | `/tmp/my-test-cache` |
| `my-test-cache` | `<workspace root>/my-test-cache` | 

Where `<workspace root>` for me looked like `/private/var/tmp/_bazel_…/…/sandbox/darwin-sandbox/…/execroot/_main`.

Closes #83
Closes #183
Closes #187 