### PR TITLE
fix: provide cc_toolchain artifacts required for assembly actions

### DIFF
--- a/toolchain/private/cc_toolchains.bzl
+++ b/toolchain/private/cc_toolchains.bzl
@@ -60,6 +60,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
             toolchain_config = ":%s_cc_config" % zigtarget,
             all_files = "//:{}_all_files".format(zigtarget),
             ar_files = "//:{}_ar_files".format(zigtarget),
+            as_files = "//:{}_compiler_files".format(zigtarget),
             compiler_files = "//:{}_compiler_files".format(zigtarget),
             linker_files = "//:{}_linker_files".format(zigtarget),
             dwp_files = "//:empty",


### PR DESCRIPTION
Currently, having an assembly source file as srcs of a cc_library will fail because compiler files are missing from the sandbox:
```
src/main/tools/process-wrapper-legacy.cc:80: "execvp(external/hermetic_cc_toolchain~~toolchains~zig_sdk/tools/x86_64-linux-gnu.2.36/c++, ...)": No such file or directory
```

This PR fixes that.