### PR TITLE
fix: dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ use_repo(
     "com_github_tetratelabs_wazero",
 )
 
-toolchains = use_extension("//toolchain:ext.bzl", "toolchains")
+toolchains = use_extension("//toolchain:ext.bzl", "toolchains", dev_dependency = True)
 use_repo(toolchains, "zig_sdk")
 
 # TODO: register all toolchains by:

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -95,7 +95,7 @@ def toolchains(
         host_platform_ext = host_platform_ext,
     )
 
-    indirect_repos = ["zig_config"]
+    private_repos = ["zig_config"]
 
     for os, archs in exec_platforms.items():
         for arch in archs:
@@ -108,11 +108,11 @@ def toolchains(
                 exec_os = os,
                 exec_arch = arch,
             )
-            indirect_repos.append("zig_config-{}-{}".format(os, arch))
+            private_repos.append("zig_config-{}-{}".format(os, arch))
 
     return struct(
-        direct = ["zig_sdk"],
-        indirect = indirect_repos,
+        public = ["zig_sdk"],
+        private = private_repos,
     )
 
 def _quote(s):

--- a/toolchain/ext.bzl
+++ b/toolchain/ext.bzl
@@ -17,23 +17,30 @@ _exec_platform = tag_class(
 
 def _toolchains_impl(mctx):
     exec_platforms = {}
+    root_direct_deps = []
+    root_direct_dev_deps = []
+    is_non_dev_dependency = mctx.root_module_has_non_dev_dependency
 
     for mod in mctx.modules:
-        for ep in mod.tags.exec_platform:
-            _archs = exec_platforms.get(ep.os, list())
-            if ep.arch not in _archs:
-                _archs.append(ep.arch)
-            exec_platforms[ep.os] = _archs
+        if mod.is_root:
+            for ep in mod.tags.exec_platform:
+                _archs = exec_platforms.get(ep.os, list())
+                if ep.arch not in _archs:
+                    _archs.append(ep.arch)
+                exec_platforms[ep.os] = _archs
 
-    repos = zig_toolchains(exec_platforms = exec_platforms)
+            repos = zig_toolchains(exec_platforms = exec_platforms)
+
+            root_direct_deps = list(repos.public) if is_non_dev_dependency else []
+            root_direct_dev_deps = list(repos.public) if not is_non_dev_dependency else []
 
     metadata_kwargs = {}
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         metadata_kwargs["reproducible"] = True
 
     return mctx.extension_metadata(
-        root_module_direct_deps = repos.direct,
-        root_module_direct_dev_deps = [],
+        root_module_direct_deps = root_direct_deps,
+        root_module_direct_dev_deps = root_direct_dev_deps,
         **metadata_kwargs
     )
 


### PR DESCRIPTION
`use_extension()` allows to set `dev_dependency = Ture`.
This needs reflection in returned extension metadata, i.e.,
- `root_module_direct_deps`
- `root_module_direct_dev_deps`.

This PR fixes `root_module_direct_dev_deps` always set to empty list as also `root_module_direct_deps` set with generated repo list to proper values taking into account `dev_dependency` value.

Fixes #210 & Closes #210.