### PR TITLE
Add path to add extra settings to toolchains

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -2,6 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "use_netrc")
 load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "target_structs", "transform_os_name", "zig_tool_path")
 load("@hermetic_cc_toolchain//toolchain/private:repositories.bzl", "zig_sdk_repository")
+load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
 load(
     "@hermetic_cc_toolchain//toolchain/private:zig_sdk.bzl",
     "HOST_PLATFORM_SHA256",
@@ -64,7 +65,8 @@ def toolchains(
         url_formats = [],
         host_platform_sha256 = HOST_PLATFORM_SHA256,
         host_platform_ext = _HOST_PLATFORM_EXT,
-        exec_platforms = {}):
+        exec_platforms = {},
+        extra_target_settings = []):
     """
         Download zig toolchain and declare bazel toolchains.
         The platforms are not registered automatically, that should be done by
@@ -84,6 +86,7 @@ def toolchains(
     zig_sdk_repository(
         name = "zig_sdk",
         exec_platforms = exec_platforms,
+        extra_target_settings = extra_target_settings,
     )
 
     # create configs for the HOST
@@ -114,9 +117,6 @@ def toolchains(
         public = ["zig_sdk"],
         private = private_repos,
     )
-
-def _quote(s):
-    return "'" + s.replace("'", "'\\''") + "'"
 
 def _zig_repository_impl(repository_ctx):
     exec_os = repository_ctx.attr.exec_os
@@ -166,8 +166,8 @@ def _zig_repository_impl(repository_ctx):
             Label(src),
             executable = False,
             substitutions = {
-                "{zig_sdk_path}": _quote("external/zig_sdk"),
-                "{os}": _quote(exec_os),
+                "{zig_sdk_path}": quote("external/zig_sdk"),
+                "{os}": quote(exec_os),
                 "{exec_os}": exec_os,
                 "{exec_cpu}": exec_arch,
             },

--- a/toolchain/libc_aware/toolchain/BUILD.bazel.tmpl
+++ b/toolchain/libc_aware/toolchain/BUILD.bazel.tmpl
@@ -7,4 +7,4 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-declare_libc_aware_toolchains(configs = {configs})
+declare_libc_aware_toolchains(configs = {configs}, extra_target_settings = {extra_target_settings})

--- a/toolchain/private/repositories.bzl
+++ b/toolchain/private/repositories.bzl
@@ -1,12 +1,16 @@
 load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "transform_arch_name", "transform_os_name")
+load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
 
 def _define_zig_toolchains(repository_ctx, configs, package = ""):
+    extra_target_settings = "[" + " ".join([quote(str(setting)) + "," for setting in repository_ctx.attr.extra_target_settings]) + "]"
+
     repository_ctx.template(
         "toolchain/{}BUILD".format(package),
         Label("//toolchain/toolchain:BUILD.bazel.tmpl"),
         executable = False,
         substitutions = {
             "{configs}": repr(configs),
+            "{extra_target_settings}": extra_target_settings,
         },
     )
 
@@ -16,6 +20,7 @@ def _define_zig_toolchains(repository_ctx, configs, package = ""):
         executable = False,
         substitutions = {
             "{configs}": repr(configs),
+            "{extra_target_settings}": extra_target_settings,
         },
     )
 
@@ -93,6 +98,9 @@ zig_sdk_repository = repository_rule(
         "exec_platforms": attr.string_list_dict(
             doc = "Dictionary, where the keys are oses and the values are lists of supported architectures",
             mandatory = True,
+        ),
+        "extra_target_settings": attr.label_list(
+            doc = "Additional settings to add to the generated toolchains, to make them more restrictive",
         ),
     },
     implementation = _zig_sdk_repository_impl,

--- a/toolchain/toolchain/BUILD.bazel.tmpl
+++ b/toolchain/toolchain/BUILD.bazel.tmpl
@@ -4,4 +4,4 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-declare_toolchains(configs = {configs})
+declare_toolchains(configs = {configs}, extra_target_settings = {extra_target_settings})

--- a/toolchain/utils.bzl
+++ b/toolchain/utils.bzl
@@ -1,0 +1,2 @@
+def quote(s):
+    return "'" + s.replace("'", "'\\''") + "'"


### PR DESCRIPTION
This will allow toolchains to be configurably more restrictive, e.g. by requiring a setting to be enabled in order to select the hermetic toolchains.

This could be a solution to https://github.com/uber/hermetic_cc_toolchain/issues/205.