### PR TITLE
Avoid modifying frozen list

### DIFF
--- a/toolchain/private/repositories.bzl
+++ b/toolchain/private/repositories.bzl
@@ -68,12 +68,9 @@ alias(
     _define_zig_toolchains(repository_ctx, "@zig_config")
 
     # Remove the HOST to not duplicate Zig HOST toolchains (@zig_config)
-    exec_platforms = repository_ctx.attr.exec_platforms
-
-    _archs = exec_platforms.get(_os, list())
-    if _arch in _archs:
-        _archs.remove(_arch)
-        exec_platforms[_os] = _archs
+    exec_platforms = dict(repository_ctx.attr.exec_platforms)
+    exec_archs = exec_platforms.get(_os, list())
+    exec_platforms[_os] = [a for a in exec_archs if a != _arch]
 
     for os, archs in exec_platforms.items():
         for arch in archs:


### PR DESCRIPTION
`repository_ctx.attr.exec_platforms` and its values are all frozen. We cannot remove host platforms from them. So when we have this in WORKSPACE:

```starlark
RBE_PLATFORMS = {
    "linux": ["amd64", "arm64"],
}

zig_toolchains(
  exec_platforms = RBE_PLATFORMS
)
```

Builds would fail on Linux because:

```
        File "/home/user/.cache/bazel/_bazel_zplin/391a7464ab75ac3a8cb620cc52c50a30/external/hermetic_cc_toolchain/toolchain/private/repositories.bzl", line 75, column 22, in _zig_sdk_repository_impl
                _archs.remove(_arch)
Error in remove: trying to mutate a frozen list value
ERROR: Target parsing failed due to unexpected exception: trying to mutate a frozen list value
```

This PR creates a regular dictionary out of the frozen one so we can remove the host platforms from `exec_platforms`

@birunts  can you review?