### PR TITLE
Support Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 
 bazel_dep(name = "rules_go", version = "0.54.0", dev_dependency = True)
 

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -1,8 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_user_netrc", "use_netrc")
+load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
 load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "target_structs", "transform_os_name", "zig_tool_path")
 load("@hermetic_cc_toolchain//toolchain/private:repositories.bzl", "zig_sdk_repository")
-load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
 load(
     "@hermetic_cc_toolchain//toolchain/private:zig_sdk.bzl",
     "HOST_PLATFORM_SHA256",

--- a/toolchain/private/cc_toolchains.bzl
+++ b/toolchain/private/cc_toolchains.bzl
@@ -1,4 +1,5 @@
 load("@hermetic_cc_toolchain//toolchain:zig_cc_toolchain.bzl", "zig_cc_toolchain_config")
+load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
 load(":defs.bzl", "target_structs", "zig_tool_path")
 
 def declare_cc_toolchains(os, zig_sdk_path):
@@ -54,7 +55,7 @@ def declare_cc_toolchains(os, zig_sdk_path):
             visibility = ["//visibility:private"],
         )
 
-        native.cc_toolchain(
+        cc_toolchain(
             name = zigtarget + "_cc",
             toolchain_identifier = zigtarget + "-toolchain",
             toolchain_config = ":%s_cc_config" % zigtarget,

--- a/toolchain/private/repositories.bzl
+++ b/toolchain/private/repositories.bzl
@@ -1,5 +1,5 @@
-load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "transform_arch_name", "transform_os_name")
 load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
+load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "transform_arch_name", "transform_os_name")
 
 def _define_zig_toolchains(repository_ctx, configs, package = ""):
     extra_target_settings = "[" + " ".join([quote(str(setting)) + "," for setting in repository_ctx.attr.extra_target_settings]) + "]"

--- a/toolchain/zig_cc_toolchain.bzl
+++ b/toolchain/zig_cc_toolchain.bzl
@@ -1,6 +1,6 @@
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load(
-    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "artifact_name_pattern",
     "feature",
     "feature_set",
@@ -9,6 +9,8 @@ load(
     "tool",
     "tool_path",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 
 all_link_actions = [
     ACTION_NAMES.cpp_link_executable,


### PR DESCRIPTION
Bazel 9 moves away from the native C/C++ targets, and requires an implicit dependency on `rules_cc`.