### PR TITLE
add support for riscv64+musl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 
-bazel_dep(name = "rules_go", version = "0.54.0", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True)
 
 go_sdk = use_extension(
     "@rules_go//go:extensions.bzl",
@@ -55,6 +55,9 @@ register_toolchains(
     # wasm/wasi toolchains
     "@zig_sdk//toolchain:wasip1_wasm",
     "@zig_sdk//toolchain:none_wasm",
+
+    # riscv64 toolchains for libc-aware platforms:
+    "@zig_sdk//libc_aware/toolchain:linux_riscv64_musl",
 
     # zig toolchains
     "@zig_sdk//toolchain:zig",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.6
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44
-	github.com/bazelbuild/rules_go v0.54.0
+	github.com/bazelbuild/rules_go v0.59.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tetratelabs/wazero v1.6.0
 )

--- a/test/glibc_hacks/BUILD
+++ b/test/glibc_hacks/BUILD
@@ -21,5 +21,6 @@ cc_binary(
         ("linux_amd64_musl", "//libc_aware/platform:linux_amd64_musl"),
         ("linux_amd64_gnu.2.28", "//libc_aware/platform:linux_amd64_gnu.2.28"),
         ("linux_arm64_musl", "//libc_aware/platform:linux_arm64_musl"),
+        ("linux_riscv64_musl_zig", "//libc_aware/platform:linux_riscv64_musl_zig"),
     ]
 ]

--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -22,6 +22,7 @@ _DEFAULT_INCLUDE_DIRECTORIES = [
 
 _HOST_PLATFORM_EXT = {
     "linux-aarch64": "tar.xz",
+    "linux-riscv64": "tar.xz",
     "linux-x86_64": "tar.xz",
     "macos-aarch64": "tar.xz",
     "macos-x86_64": "tar.xz",
@@ -32,6 +33,7 @@ _HOST_PLATFORM_EXT = {
 # map bazel's host_platform to zig's -target= and -mcpu=
 _TARGET_MCPU = {
     "linux-aarch64": ("aarch64-linux-musl", "baseline"),
+    "linux-riscv64": ("riscv64-linux-musl", "baseline"),
     "linux-x86_64": ("x86_64-linux-musl", "baseline"),
     "macos-aarch64": ("aarch64-macos-none", "apple_a14"),
     "macos-x86_64": ("x86_64-macos-none", "baseline"),

--- a/toolchain/ext.bzl
+++ b/toolchain/ext.bzl
@@ -8,7 +8,7 @@ _exec_platform = tag_class(
             mandatory = True,
         ),
         "arch": attr.string(
-            values = ["amd64", "arm64"],
+            values = ["amd64", "arm64", "riscv64"],
             mandatory = True,
         ),
     },

--- a/toolchain/platform/defs.bzl
+++ b/toolchain/platform/defs.bzl
@@ -32,18 +32,38 @@ def declare_libc_aware_platforms():
                 extra_constraints = ["//libc:{}".format(libc)],
             )
 
+    declare_platform(
+        "riscv64",
+        "riscv64",
+        "linux",
+        "linux",
+        suffix = "_{}".format("musl"),
+        extra_constraints = ["//libc:{}".format("musl")],
+    )
+
 def declare_platform(gocpu, zigcpu, bzlos, os, suffix = "", extra_constraints = []):
     constraint_values = [
         "@platforms//os:{}".format(bzlos),
         "@platforms//cpu:{}".format(zigcpu),
     ] + extra_constraints
 
+    if gocpu != zigcpu:
+        native.platform(
+            name = "{os}_{zigcpu}{suffix}".format(os = os, zigcpu = zigcpu, suffix = suffix),
+            constraint_values = constraint_values,
+        )
+        native.platform(
+            name = "{os}_{gocpu}{suffix}".format(os = os, gocpu = gocpu, suffix = suffix),
+            constraint_values = constraint_values,
+        )
+        return
+
+    # for riscv64, zigcpu==gocpu
     native.platform(
-        name = "{os}_{zigcpu}{suffix}".format(os = os, zigcpu = zigcpu, suffix = suffix),
+        name = "{os}_{zigcpu}{suffix}_zig".format(os = os, zigcpu = zigcpu, suffix = suffix),
         constraint_values = constraint_values,
     )
-
     native.platform(
-        name = "{os}_{gocpu}{suffix}".format(os = os, gocpu = gocpu, suffix = suffix),
+        name = "{os}_{gocpu}{suffix}_go".format(os = os, gocpu = gocpu, suffix = suffix),
         constraint_values = constraint_values,
     )

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -50,6 +50,7 @@ def target_structs():
             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
     ret.append(_target_wasm())
     ret.append(_target_wasm_no_wasi())
+    ret.append(_target_linux_musl("riscv64", "riscv64"))
     return ret
 
 def _target_macos(gocpu, zigcpu):
@@ -184,7 +185,8 @@ def _target_linux_musl(gocpu, zigcpu):
                    ] +
                    # x86_64-linux-any is x86_64-linux and x86-linux combined.
                    (["libc/include/x86-linux-any"] if zigcpu == "x86_64" else []) +
-                   (["libc/include/{}-linux-any".format(zigcpu)] if zigcpu != "x86_64" else []) + [
+                   (["libc/include/aarch64-linux-any".format(zigcpu)] if zigcpu == "aarch64" else []) +
+                   (["libc/include/riscv-linux-any"] if zigcpu == "riscv64" else []) + [
             "libc/include/any-linux-any",
         ] + _INCLUDE_TAIL,
         linkopts = [],

--- a/toolchain/private/zig_sdk.bzl
+++ b/toolchain/private/zig_sdk.bzl
@@ -2,6 +2,7 @@ VERSION = "0.12.0"
 
 HOST_PLATFORM_SHA256 = {
     "linux-aarch64": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+    "linux-riscv64": "bb2d1a78b01595a9c00ffd2e12ab46e32f8b6798f76aec643ff78e5b4f5c5afd",
     "linux-x86_64": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad",
     "macos-aarch64": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f",
     "macos-x86_64": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -285,7 +285,7 @@ fn getRunMode(self_exe: []const u8, self_base_noexe: []const u8) error{BadParent
     var it = mem.split(u8, triple, "-");
 
     const arch = it.next() orelse return error.BadParent;
-    if (mem.indexOf(u8, "aarch64,x86_64,wasm32", arch) == null)
+    if (mem.indexOf(u8, "aarch64,x86_64,wasm32,riscv64", arch) == null)
         return error.BadParent;
 
     const got_os = it.next() orelse return error.BadParent;


### PR DESCRIPTION
Hi there.


Recently, riscv64 (rv64) has gained widespread adoption, and I'm very interested in rv64 as well. Recently, I am trying to add rv64 support to [zstd-prebuilt](https://github.com/aspect-build/zstd-prebuilt), and found that `hermetic_cc_toolchain` needs to add rv64 support first, which led to this PR.

Adding rv64 support to the current repository is not an easy task. As mentioned in the README, I'm also quite confused about configuring toolchains in Bazel. However, overall, I successfully completed adding rv64 support to `zstd-prebuilt`. Below is a detailed introduction.

### 1. Zig's support for rv64
In version 0.12.0, zig does have support for rv64, but only for musl. For glibc, there's an issue in cross-compilation environments that's basically consistent with what's reported in this [issue](https://github.com/ziglang/zig/issues/19107). Upgrading to zig 0.14.0 would solve this problem, but the 0.12.0 -> 0.14.0 transition involves some breaking changes that would require too many modifications. Taking everything into consideration, this PR will not upgrade zig for now.

### 2. Only adding support for riscv64_with_musl
`zstd-prebuilt` uses `@zig_sdk//libc_aware/toolchain:linux_arm64_musl` for arm64 builds. To replicate the existing logic as much as possible, my goal is to also add musl support for rv64. Overall, adding support for `riscv64_with_musl` went quite smoothly. The environment used by `zstd-prebuilt` is precisely a cross-compilation environment.

I understand that for `hermetic_cc_toolchain`, adding support for `riscv64_with_glibc` would also be very meaningful. I attempted this, but the results were not satisfactory. As mentioned above, zig 0.12.0 has issues with `riscv64_with_glibc` under cross-compilation.

### 3. Current state of riscv64 testing
For `zstd-prebuilt`, I can successfully use `riscv64_with_musl` to complete the build. The CI shows everything went smoothly - see details [In My Fork for zstd-prebuilt](https://github.com/ffgan/zstd-prebuilt/actions/runs/20326978943/job/58394177677). This means that `hermetic_cc_toolchain` can provide good support for `riscv64_with_musl`.

As for running `hermetic_cc_toolchain` on rv64 (non-cross-compilation), since support for `riscv64_with_glibc` cannot be added, builds and tests that use glibc cannot run. However, for `//test/glibc_hacks/...`, I tested it and it can execute smoothly.

### 4. Summary
In fact, I'm still confused about configuring related toolchains in Bazel to this day. So if you're equally confused about the above content, please feel free to @ me. I'll do my best to answer 😭😭




---
**Other Info**
Co-authored by: nijincheng@iscas.ac.cn;