### PR TITLE
fix: typo in the example code for MODULE.bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ use_repo(toolchains, "zig_sdk")
 register_toolchains(
     "@zig_sdk//toolchain/...",
     "@zig_sdk//libc_aware/toolchain/...",
+)
 ```
 
 ### Configuration file


### PR DESCRIPTION
Missing `)`

`¯\_(ツ)_/¯`