### PR TITLE
Add `extra_{exec,target}_compatible_with` extensions

### DIFF
--- a/toolchain/defs.bzl
+++ b/toolchain/defs.bzl
@@ -66,6 +66,8 @@ def toolchains(
         host_platform_sha256 = HOST_PLATFORM_SHA256,
         host_platform_ext = _HOST_PLATFORM_EXT,
         exec_platforms = {},
+        extra_exec_compatible_with = [],
+        extra_target_compatible_with = [],
         extra_target_settings = []):
     """
         Download zig toolchain and declare bazel toolchains.
@@ -86,6 +88,8 @@ def toolchains(
     zig_sdk_repository(
         name = "zig_sdk",
         exec_platforms = exec_platforms,
+        extra_exec_compatible_with = extra_exec_compatible_with,
+        extra_target_compatible_with = extra_target_compatible_with,
         extra_target_settings = extra_target_settings,
     )
 

--- a/toolchain/libc_aware/toolchain/BUILD.bazel.tmpl
+++ b/toolchain/libc_aware/toolchain/BUILD.bazel.tmpl
@@ -7,4 +7,9 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-declare_libc_aware_toolchains(configs = {configs}, extra_target_settings = {extra_target_settings})
+declare_libc_aware_toolchains(
+    configs = {configs},
+    extra_exec_compatible_with = {extra_exec_compatible_with},
+    extra_target_compatible_with = {extra_target_compatible_with},
+    extra_target_settings = {extra_target_settings},
+)

--- a/toolchain/private/repositories.bzl
+++ b/toolchain/private/repositories.bzl
@@ -2,6 +2,8 @@ load("@hermetic_cc_toolchain//toolchain:utils.bzl", "quote")
 load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "transform_arch_name", "transform_os_name")
 
 def _define_zig_toolchains(repository_ctx, configs, package = ""):
+    extra_exec_compatible_with = "[" + " ".join([quote(str(setting)) + "," for setting in repository_ctx.attr.extra_exec_compatible_with]) + "]"
+    extra_target_compatible_with = "[" + " ".join([quote(str(setting)) + "," for setting in repository_ctx.attr.extra_target_compatible_with]) + "]"
     extra_target_settings = "[" + " ".join([quote(str(setting)) + "," for setting in repository_ctx.attr.extra_target_settings]) + "]"
 
     repository_ctx.template(
@@ -10,6 +12,8 @@ def _define_zig_toolchains(repository_ctx, configs, package = ""):
         executable = False,
         substitutions = {
             "{configs}": repr(configs),
+            "{extra_exec_compatible_with}": extra_exec_compatible_with,
+            "{extra_target_compatible_with}": extra_target_compatible_with,
             "{extra_target_settings}": extra_target_settings,
         },
     )
@@ -20,6 +24,8 @@ def _define_zig_toolchains(repository_ctx, configs, package = ""):
         executable = False,
         substitutions = {
             "{configs}": repr(configs),
+            "{extra_exec_compatible_with}": extra_exec_compatible_with,
+            "{extra_target_compatible_with}": extra_target_compatible_with,
             "{extra_target_settings}": extra_target_settings,
         },
     )
@@ -95,6 +101,12 @@ zig_sdk_repository = repository_rule(
         "exec_platforms": attr.string_list_dict(
             doc = "Dictionary, where the keys are oses and the values are lists of supported architectures",
             mandatory = True,
+        ),
+        "extra_exec_compatible_with": attr.label_list(
+            doc = "Additional constraints added to the `exec_compatible_with` attribute of each generated toolchain",
+        ),
+        "extra_target_compatible_with": attr.label_list(
+            doc = "Additional constraints added to the `target_compatible_with` attribute of each generated toolchain",
         ),
         "extra_target_settings": attr.label_list(
             doc = "Additional settings to add to the generated toolchains, to make them more restrictive",

--- a/toolchain/toolchain/BUILD.bazel.tmpl
+++ b/toolchain/toolchain/BUILD.bazel.tmpl
@@ -4,4 +4,9 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-declare_toolchains(configs = {configs}, extra_target_settings = {extra_target_settings})
+declare_toolchains(
+    configs = {configs},
+    extra_exec_compatible_with = {extra_exec_compatible_with},
+    extra_target_compatible_with = {extra_target_compatible_with},
+    extra_target_settings = {extra_target_settings},
+)


### PR DESCRIPTION
This adds `extra_exec_compatible_with` and `extra_target_compatible_with` as extensions so that users can control whether the toolchains generated by hermetic_cc_toolchain are selected.

This is intended to fix https://github.com/uber/hermetic_cc_toolchain/issues/205