### PR TITLE
chore: upgrade Zig from 0.12.0 to 0.14.0

### DIFF
--- a/toolchain/private/zig_sdk.bzl
+++ b/toolchain/private/zig_sdk.bzl
@@ -1,12 +1,12 @@
-VERSION = "0.12.0"
+VERSION = "0.14.0"
 
 HOST_PLATFORM_SHA256 = {
-    "linux-aarch64": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
-    "linux-x86_64": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad",
-    "macos-aarch64": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f",
-    "macos-x86_64": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
-    "windows-aarch64": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b",
-    "windows-x86_64": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5",
+    "linux-aarch64": "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f",
+    "linux-x86_64": "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982",
+    "macos-aarch64": "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e",
+    "macos-x86_64": "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3",
+    "windows-aarch64": "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046",
+    "windows-x86_64": "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371",
 }
 
 # Official recommended version. Should use this when we have a usable release.

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -93,7 +93,7 @@ const ParseResults = union(Action) {
 };
 
 // sub-commands in the same folder as `zig-wrapper`
-const sub_commands_target = std.ComptimeStringMap(void, .{
+const sub_commands_target = std.StaticStringMap(void, .{
     .{"ar"},
     .{"ld.lld"},
     .{"lld-link"},


### PR DESCRIPTION
## Summary

Upgrade the default Zig version from 0.12.0 to 0.14.0 and update the SHA256 hashes for all host platforms.

## Why

Zig 0.14.0 includes MinGW pthreads support (ziglang/zig#22156), which is required for Windows cross-compilation targets that use threading.

## Changes

- `toolchain/private/zig_sdk.bzl`: Updated `VERSION` from `0.12.0` to `0.14.0`
- Updated all `HOST_PLATFORM_SHA256` entries with hashes from https://ziglang.org/download/index.json
- No URL format changes needed — Zig 0.14.0 still uses the `zig-{host_platform}-{version}` naming convention (the format changed in 0.14.1)