### PR TITLE
Pass explicit -target to zig on macOS

### DIFF
--- a/ci/zig-utils
+++ b/ci/zig-utils
@@ -5,6 +5,17 @@ set -xeuo pipefail
 echo "--- which zig"
 ZIG=${ZIG:-$(tools/bazel run "$@" --run_under=echo @zig_sdk//:zig)}
 
+# On macOS, pass an explicit -target so zig links against its bundled
+# hermetic libc stubs instead of the host SDK. Without it, zig 0.14.0 fails
+# to parse the libSystem.tbd shipped with newer Xcode SDKs
+# (ziglang/zig#23324) and yields undefined-symbol link errors. Other
+# platforms build natively and need no target override.
+TARGET_ARGS=()
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)  TARGET_ARGS=(-target aarch64-macos-none) ;;
+  Darwin-x86_64) TARGET_ARGS=(-target x86_64-macos-none) ;;
+esac
+
 for zigfile in $(git ls-files '*.zig'); do
-  $ZIG test "$zigfile"
+  $ZIG test ${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"} "$zigfile"
 done

--- a/rules/zig_binary.bzl
+++ b/rules/zig_binary.bzl
@@ -2,11 +2,26 @@ def _impl(ctx):
     zig_info = ctx.toolchains["@zig_sdk//toolchain/zig:toolchain_type"].ziginfo
     dst = ctx.actions.declare_file(ctx.label.name)
 
+    # Match the platform -> (target, mcpu) mapping used by the toolchain
+    # (see toolchain/defs.bzl::_TARGET_MCPU) so the rule links against zig's
+    # bundled hermetic libc stubs instead of the host SDK. Without an explicit
+    # -target, zig 0.14.0 links against the host macOS SDK, whose libSystem.tbd
+    # is unparseable on newer Xcode/SDKs (ziglang/zig#23324), yielding
+    # undefined-symbol link errors.
     macos = ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]
+    linux = ctx.attr._linux_constraint[platform_common.ConstraintValueInfo]
+    windows = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
     aarch64 = ctx.attr._aarch64_constraint[platform_common.ConstraintValueInfo]
-    if ctx.target_platform_has_constraint(macos) and ctx.target_platform_has_constraint(aarch64):
-        mcpu = "apple_a14"
+
+    if ctx.target_platform_has_constraint(macos):
+        target = "aarch64-macos-none" if ctx.target_platform_has_constraint(aarch64) else "x86_64-macos-none"
+        mcpu = "apple_a14" if ctx.target_platform_has_constraint(aarch64) else "baseline"
+    elif ctx.target_platform_has_constraint(windows):
+        target = "aarch64-windows-gnu" if ctx.target_platform_has_constraint(aarch64) else "x86_64-windows-gnu"
+        mcpu = "baseline"
     else:
+        # linux or anything else: use musl, which is fully hermetic
+        target = "aarch64-linux-musl" if ctx.target_platform_has_constraint(aarch64) else "x86_64-linux-musl"
         mcpu = "baseline"
 
     ctx.actions.run(
@@ -17,6 +32,8 @@ def _impl(ctx):
         arguments = [
             "build-exe",
             ctx.file.src.short_path,
+            "-target",
+            target,
             "-mcpu={}".format(mcpu),
             "-femit-bin={}".format(dst.path),
             "-lc",
@@ -38,6 +55,12 @@ zig_binary = rule(
         ),
         "_macos_constraint": attr.label(
             default = "@platforms//os:macos",
+        ),
+        "_linux_constraint": attr.label(
+            default = "@platforms//os:linux",
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
         ),
         "_aarch64_constraint": attr.label(
             default = "@platforms//cpu:aarch64",

--- a/rules/zig_binary.bzl
+++ b/rules/zig_binary.bzl
@@ -2,26 +2,24 @@ def _impl(ctx):
     zig_info = ctx.toolchains["@zig_sdk//toolchain/zig:toolchain_type"].ziginfo
     dst = ctx.actions.declare_file(ctx.label.name)
 
-    # Match the platform -> (target, mcpu) mapping used by the toolchain
-    # (see toolchain/defs.bzl::_TARGET_MCPU) so the rule links against zig's
-    # bundled hermetic libc stubs instead of the host SDK. Without an explicit
-    # -target, zig 0.14.0 links against the host macOS SDK, whose libSystem.tbd
-    # is unparseable on newer Xcode/SDKs (ziglang/zig#23324), yielding
-    # undefined-symbol link errors.
+    # On macOS, pass an explicit -target so zig links against its bundled
+    # hermetic libc stubs instead of the host SDK. Without it, zig 0.14.0
+    # links against the host macOS SDK, whose libSystem.tbd is unparseable
+    # on newer Xcode/SDKs (ziglang/zig#23324), yielding undefined-symbol
+    # link errors. Other platforms build natively as before: Linux glibc
+    # detection works, and on Windows zig bundles the mingw-w64 libc.
     macos = ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]
-    linux = ctx.attr._linux_constraint[platform_common.ConstraintValueInfo]
-    windows = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
     aarch64 = ctx.attr._aarch64_constraint[platform_common.ConstraintValueInfo]
 
+    target_args = []
     if ctx.target_platform_has_constraint(macos):
-        target = "aarch64-macos-none" if ctx.target_platform_has_constraint(aarch64) else "x86_64-macos-none"
-        mcpu = "apple_a14" if ctx.target_platform_has_constraint(aarch64) else "baseline"
-    elif ctx.target_platform_has_constraint(windows):
-        target = "aarch64-windows-gnu" if ctx.target_platform_has_constraint(aarch64) else "x86_64-windows-gnu"
-        mcpu = "baseline"
+        if ctx.target_platform_has_constraint(aarch64):
+            target_args = ["-target", "aarch64-macos-none"]
+            mcpu = "apple_a14"
+        else:
+            target_args = ["-target", "x86_64-macos-none"]
+            mcpu = "baseline"
     else:
-        # linux or anything else: use musl, which is fully hermetic
-        target = "aarch64-linux-musl" if ctx.target_platform_has_constraint(aarch64) else "x86_64-linux-musl"
         mcpu = "baseline"
 
     ctx.actions.run(
@@ -32,8 +30,7 @@ def _impl(ctx):
         arguments = [
             "build-exe",
             ctx.file.src.short_path,
-            "-target",
-            target,
+        ] + target_args + [
             "-mcpu={}".format(mcpu),
             "-femit-bin={}".format(dst.path),
             "-lc",
@@ -55,12 +52,6 @@ zig_binary = rule(
         ),
         "_macos_constraint": attr.label(
             default = "@platforms//os:macos",
-        ),
-        "_linux_constraint": attr.label(
-            default = "@platforms//os:linux",
-        ),
-        "_windows_constraint": attr.label(
-            default = "@platforms//os:windows",
         ),
         "_aarch64_constraint": attr.label(
             default = "@platforms//cpu:aarch64",


### PR DESCRIPTION
On macOS 26 (Xcode/CommandLineTools with MacOSX26.x.sdk), bazel build //rules:cp and ci/zig-utils both fail with undefined-symbol link errors (_abort, _getenv, _sigaction, __availability_version_check, …).

## Root cause
Both code paths invoke zig without a -target, so zig links against the host macOS SDK's libSystem.tbd. Zig 0.14.0's TAPI parser can't parse the tbd shipped with newer Xcode SDKs (ziglang/zig#23324) and silently yields zero symbols. Confirmed by isolation: the same commands with -target aarch64-macos-none or an older SDK sysroot link and run.

## Fix
Pass an explicit -target <triple> on macOS only, so zig links against its bundled hermetic libc stubs instead of the host SDK. Linux and Windows are untouched — they build natively as before (Linux glibc detection works, Windows bundles mingw-w64 libc).
- rules/zig_binary.bzl — adds -target aarch64-macos-none / x86_64-macos-none for macOS targets; other platforms pass no target.
- ci/zig-utils — adds -target <triple> for Darwin-* hosts only; non-Darwin runs zig test with no target flag.