### PR TITLE
Upgrade Zig toolchain to 0.16.0

### DIFF
--- a/rules/cp.zig
+++ b/rules/cp.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const argv = try std.process.argsAlloc(gpa.allocator());
-    defer std.process.argsFree(gpa.allocator(), argv);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const argv = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (argv.len != 3) return error.InvalidUsage;
-    try std.fs.cwd().copyFile(argv[1], std.fs.cwd(), argv[2], .{});
+    const cwd = std.Io.Dir.cwd();
+    try cwd.copyFile(argv[1], cwd, argv[2], io, .{});
 }

--- a/toolchain/private/defs.bzl
+++ b/toolchain/private/defs.bzl
@@ -67,7 +67,9 @@ def _target_macos(gocpu, zigcpu):
         includes = [
             "libunwind/include",
             "libc/darwin",
-            "libc/include/any-macos-any",
+            # Zig 0.16 renamed the any-macos-any libc-include dir to
+            # any-darwin-any.
+            "libc/include/any-darwin-any",
         ] + _INCLUDE_TAIL,
         linkopts = ["-Wl,-headerpad_max_install_names"],
         dynamic_library_linkopts = ["-Wl,-undefined=dynamic_lookup"],

--- a/toolchain/private/zig_sdk.bzl
+++ b/toolchain/private/zig_sdk.bzl
@@ -1,12 +1,12 @@
-VERSION = "0.15.2"
+VERSION = "0.16.0"
 
 HOST_PLATFORM_SHA256 = {
-    "linux-aarch64": "958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f",
-    "linux-x86_64": "02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239",
-    "macos-aarch64": "3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b",
-    "macos-x86_64": "375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f",
-    "windows-aarch64": "b926465f8872bf983422257cd9ec248bb2b270996fbe8d57872cca13b56fc370",
-    "windows-x86_64": "3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c",
+    "linux-aarch64": "ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17",
+    "linux-x86_64": "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00",
+    "macos-aarch64": "b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489",
+    "macos-x86_64": "0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7",
+    "windows-aarch64": "aee38316ee4111717900f45dd3130145c39289e105541d737eb8c5ed653c78ef",
+    "windows-x86_64": "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e",
 }
 
 # Zig >=0.14.1 names its release tarballs zig-{arch}-{os}-{version} (arch

--- a/toolchain/zig-wrapper.zig
+++ b/toolchain/zig-wrapper.zig
@@ -55,7 +55,9 @@ const std = @import("std");
 const fs = std.fs;
 const mem = std.mem;
 const process = std.process;
-const ChildProcess = std.process.Child;
+const Io = std.Io;
+const Dir = std.Io.Dir;
+const Environ = std.process.Environ;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
 const sep = fs.path.sep_str;
 
@@ -84,7 +86,7 @@ const Action = enum {
 
 const ExecParams = struct {
     args: ArrayListUnmanaged([]const u8),
-    env: process.EnvMap,
+    env: *Environ.Map,
 };
 
 const ParseResults = union(Action) {
@@ -109,51 +111,59 @@ const RunMode = union(enum) {
     cc: []const u8, // cc -target <...>
 };
 
-pub fn main() u8 {
-    const allocator = if (builtin.link_libc)
-        std.heap.c_allocator
-    else blk: {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-        break :blk gpa.allocator();
-    };
-    var arena_allocator = std.heap.ArenaAllocator.init(allocator);
-    defer arena_allocator.deinit();
-    const arena = arena_allocator.allocator();
+pub fn main(init: std.process.Init) u8 {
+    // Juicy Main (Zig 0.16): the runtime hands us a pre-initialized arena,
+    // Io implementation and environment map. Everything that blocks or
+    // touches the OS (args, env, filesystem, exec) now flows through `io`.
+    const arena = init.arena.allocator();
+    const io = init.io;
 
-    var argv_it = process.argsWithAllocator(arena) catch |err|
+    var argv_it = init.minimal.args.iterateAllocator(arena) catch |err|
         return fatal("error parsing args: {s}\n", .{@errorName(err)});
 
-    const action = parseArgs(arena, fs.cwd(), &argv_it) catch |err|
+    const action = parseArgs(arena, io, Dir.cwd(), &argv_it, init.environ_map) catch |err|
         return fatal("error: {s}\n", .{@errorName(err)});
 
     switch (action) {
         .err => |msg| return fatal("{s}", .{msg}),
         .exec => |params| {
-            if (builtin.os.tag == .windows)
-                return spawnWindows(arena, params)
+            // execve-style replacement where supported (POSIX); spawn+wait
+            // on platforms that cannot replace the process image (Windows).
+            if (process.can_replace)
+                return replaceProcess(io, params)
             else
-                return execUnix(arena, params);
+                return spawnAndWait(io, params);
         },
     }
 }
 
-fn spawnWindows(arena: mem.Allocator, params: ExecParams) u8 {
-    var proc = ChildProcess.init(params.args.items, arena);
-    proc.env_map = &params.env;
-    const ret = proc.spawnAndWait() catch |err|
+fn spawnAndWait(io: Io, params: ExecParams) u8 {
+    var child = process.spawn(io, .{
+        .argv = params.args.items,
+        .environ_map = params.env,
+    }) catch |err|
         return fatal(
             "error spawning {s}: {s}\n",
             .{ params.args.items[0], @errorName(err) },
         );
 
-    switch (ret) {
-        .Exited => |code| return code,
+    const term = child.wait(io) catch |err|
+        return fatal(
+            "error waiting for {s}: {s}\n",
+            .{ params.args.items[0], @errorName(err) },
+        );
+
+    switch (term) {
+        .exited => |code| return code,
         else => |other| return fatal("abnormal exit: {any}\n", .{other}),
     }
 }
 
-fn execUnix(arena: mem.Allocator, params: ExecParams) u8 {
-    const err = process.execve(arena, params.args.items, &params.env);
+fn replaceProcess(io: Io, params: ExecParams) u8 {
+    const err = process.replace(io, .{
+        .argv = params.args.items,
+        .environ_map = params.env,
+    });
     std.debug.print(
         "error execing {s}: {s}\n",
         .{ params.args.items[0], @errorName(err) },
@@ -167,8 +177,10 @@ fn execUnix(arena: mem.Allocator, params: ExecParams) u8 {
 // Leaks memory: the name of the first argument is arena not by chance.
 fn parseArgs(
     arena: mem.Allocator,
-    cwd: fs.Dir,
+    io: Io,
+    cwd: Dir,
     argv_it: anytype,
+    env: *Environ.Map,
 ) error{OutOfMemory}!ParseResults {
     const arg0 = argv_it.next() orelse
         return parseFatal(arena, "error: argv[0] cannot be null", .{});
@@ -187,12 +199,13 @@ fn parseArgs(
 
     const root = blk: {
         var dir = cwd.openDir(
+            io,
             "external" ++ sep ++ "zig_sdk" ++ sep ++ "lib",
-            .{ .access_sub_paths = false, .no_follow = true },
+            .{ .access_sub_paths = false, .follow_symlinks = false },
         );
 
         if (dir) |*dir_exists| {
-            dir_exists.close();
+            dir_exists.close(io);
             break :blk "external" ++ sep ++ "zig_sdk";
         } else |_| {}
 
@@ -213,9 +226,6 @@ fn parseArgs(
         arena,
         &[_][]const u8{ root, "zig" ++ EXE },
     );
-
-    var env = process.getEnvMap(arena) catch |err|
-        return parseFatal(arena, "error getting env: {s}", .{@errorName(err)});
 
     const cache_dir = blk: {
         if (CACHE_DIR.len > 0) break :blk @as([]const u8, CACHE_DIR);
@@ -250,7 +260,7 @@ fn parseArgs(
     }
 
     // args is the path to the zig binary and args to it.
-    var args = ArrayListUnmanaged([]const u8){};
+    var args: ArrayListUnmanaged([]const u8) = .empty;
     try args.appendSlice(arena, &[_][]const u8{zig_exe});
 
     switch (run_mode) {
@@ -266,26 +276,37 @@ fn parseArgs(
     if (run_mode == RunMode.cc)
         try args.appendSlice(arena, &[_][]const u8{"-fno-sanitize=undefined"});
 
-    // Process arguments, transforming -u SYMBOL into -Wl,-u,SYMBOL
-    // This is needed because zig c++ doesn't handle the -u flag correctly
-    // (it tries to open the symbol name as a file instead of passing it to the linker)
+    // Go's cgo unconditionally appends the MinGW-only `-mthreads` flag when
+    // targeting Windows (golang/go#80290). Since llvm/llvm-project D151590,
+    // clang's driver treats MinGW link flags as target-specific, and zig's
+    // clang rejects `-mthreads` for windows-gnu. The flag is redundant for
+    // zig's always-threadsafe mingw-w64 runtime, so drop it when targeting
+    // Windows. The upstream fix is pending in Go 1.27.
+    const strip_mthreads = switch (run_mode) {
+        .cc => |triple| mem.indexOf(u8, triple, "windows") != null,
+        else => false,
+    };
+
+    // Also transform `-u SYMBOL` into `-Wl,-u,SYMBOL`: zig c++ mishandles the
+    // bare `-u` flag (it tries to open the symbol name as a file instead of
+    // passing it to the linker).
     while (argv_it.next()) |arg| {
+        if (strip_mthreads and mem.eql(u8, arg, "-mthreads")) continue;
         if (mem.eql(u8, arg, "-u")) {
-            // Get the next argument (the symbol name)
             if (argv_it.next()) |symbol| {
                 const transformed = try std.fmt.allocPrint(arena, "-Wl,-u,{s}", .{symbol});
                 try args.append(arena, transformed);
             }
-        } else {
-            try args.append(arena, arg);
+            continue;
         }
+        try args.append(arena, arg);
     }
 
     // Workaround for https://github.com/ziglang/zig/issues/23287: zig 0.14.0
     // lld does not handle the colon-link syntax (-l :filename or -l:filename).
     // Resolve such flags to full paths by searching the -L directories.
     if (run_mode == RunMode.cc)
-        try resolveColonLibraries(arena, cwd, &args);
+        try resolveColonLibraries(arena, io, cwd, &args);
 
     // Add -target as the last parameter. The wrapper should overwrite
     // the target specified by other tools calling the wrapper.
@@ -306,10 +327,11 @@ fn parseArgs(
 // by ":filename", resolve it to a full path by searching the -L directories.
 fn resolveColonLibraries(
     arena: mem.Allocator,
-    cwd: fs.Dir,
+    io: Io,
+    cwd: Dir,
     args: *ArrayListUnmanaged([]const u8),
 ) error{OutOfMemory}!void {
-    var lib_paths = ArrayListUnmanaged([]const u8){};
+    var lib_paths: ArrayListUnmanaged([]const u8) = .empty;
     var j: usize = 0;
     while (j < args.items.len) : (j += 1) {
         const arg = args.items[j];
@@ -332,7 +354,7 @@ fn resolveColonLibraries(
         const filename = next[1..];
         for (lib_paths.items) |lib_path| {
             const full_path = try fs.path.join(arena, &[_][]const u8{ lib_path, filename });
-            cwd.access(full_path, .{}) catch continue;
+            cwd.access(io, full_path, .{}) catch continue;
             args.items[i] = full_path;
             _ = args.orderedRemove(i + 1);
             break;
@@ -426,8 +448,9 @@ fn compareExec(
 test "zig-wrapper:parseArgs" {
     // not using testing.allocator, because parseArgs is designed to be used
     // with an arena.
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     const allocator = gpa.allocator();
+    const io = std.testing.io;
 
     const tests = [_]struct {
         args: []const [:0]const u8,
@@ -526,10 +549,11 @@ test "zig-wrapper:parseArgs" {
         defer tmp.cleanup();
 
         if (tt.precreate_dir) |dir|
-            try tmp.dir.makePath(dir);
+            try tmp.dir.createDirPath(io, dir);
 
+        var env = Environ.Map.init(allocator);
         var argv_it = TestArgIterator{ .argv = tt.args };
-        const res = try parseArgs(allocator, tmp.dir, &argv_it);
+        const res = try parseArgs(allocator, io, tmp.dir, &argv_it, &env);
 
         switch (tt.want_result) {
             .err => |want_msg| try testing.expectEqualStrings(
@@ -544,17 +568,19 @@ test "zig-wrapper:parseArgs" {
 }
 
 test "zig-wrapper:cache dir override" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     const allocator = gpa.allocator();
+    const io = std.testing.io;
 
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
+    var env = Environ.Map.init(allocator);
     var argv_it = TestArgIterator{ .argv = &[_][:0]const u8{
         "tools" ++ sep ++ "x86_64-linux-musl" ++ sep ++ "c++" ++ EXE,
         "main.c",
     } };
-    const res = try parseArgs(allocator, tmp.dir, &argv_it);
+    const res = try parseArgs(allocator, io, tmp.dir, &argv_it, &env);
 
     const cache_dir = res.exec.env.get("ZIG_LOCAL_CACHE_DIR").?;
     const global_cache_dir = res.exec.env.get("ZIG_GLOBAL_CACHE_DIR").?;


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #259** (Zig 0.15.2 upgrade) — this branch is based on the `0.15.2` branch and includes its commit. Only the second commit (`Upgrade Zig toolchain to 0.16.0`) is new here; once #259 merges, this rebases to a clean single-commit diff.

Bumps the pinned Zig SDK from **0.15.2 → 0.16.0**. The `.bzl` side only needs the version/SHA256 bump plus one include-dir rename; the real work is porting the two in-repo Zig programs to 0.16's ["Io as an interface"](https://ziglang.org/download/0.16.0/release-notes.html) stdlib rework and its "Juicy Main" entry point.

## Changes
- **`toolchain/private/zig_sdk.bzl`** — `VERSION` + all six host `SHA256`s.
- **`toolchain/private/defs.bzl`** — Zig 0.16 renamed the `any-macos-any` libc-include dir to `any-darwin-any`; the macOS target is updated to match (verified against `zig cc -v`; all other target include dirs are unchanged from 0.15).
- **`toolchain/zig-wrapper.zig`** — ported to 0.16:
  - `main` now takes `std.process.Init`, which supplies args, an arena, the `Io` implementation and a pre-built environ map (`process.argsWithAllocator`, `process.getEnvMap`, `process.execve` and `std.heap.GeneralPurposeAllocator` no longer exist).
  - Filesystem probes route through `Io.Dir`; the exec tail becomes `process.replace()`/`process.spawn()` gated on `process.can_replace` (POSIX exec vs. Windows spawn+wait, same behavior as before).
  - Tests use `std.testing.io` and `DebugAllocator`; `ArrayListUnmanaged` empty-init is now `.empty`.
  - **New workaround:** strip the MinGW-only `-mthreads` flag when targeting Windows. Go's cgo appends it unconditionally ([golang/go#80290](https://github.com/golang/go/issues/80290)), and since [llvm/llvm-project D151590](https://reviews.llvm.org/D151590) zig's clang rejects it for `windows-gnu` targets, which broke rules_go's Windows stdlib build. The flag is redundant for zig's always-threadsafe mingw-w64 runtime; the upstream Go fix is slated for Go 1.27, after which this shim can be dropped.
- **`rules/cp.zig`** — same Juicy Main / `Io.Dir` port.

## Verification (darwin-arm64)
- `tools/bazel test //...` — passes; same 4-pass/7-platform-skipped result as the 0.14.0 baseline (including the wasm and windows cross-links).
- `tools/bazel test --config=macos_toolchains --@rules_go//go/config:static --@rules_go//go/config:pure //test/c/...` — passes (native Darwin zig toolchain).
- `zig fmt --check` and `zig test` on both `.zig` files with the real 0.16.0 compiler — pass.
- buildifier on all edited files — clean.
- `examples/bzlmod` built against this module via `--override_module` — `@zig_sdk//:zig version` resolves to `0.16.0`, `cgo_test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)